### PR TITLE
feat(react): adapt Zag.js Batch 3 form inputs

### DIFF
--- a/docs/zag-coverage.md
+++ b/docs/zag-coverage.md
@@ -45,16 +45,16 @@ Legend: ✅ done · ⬜ todo
 | Menu       | `@zag-js/menu`       |   ✅   |
 | Toast      | `@zag-js/toast`      |   ✅   |
 
-### Batch 3 — form inputs ⬜
+### Batch 3 — form inputs ✅
 
 | Component    | Package                | Status |
 | ------------ | ---------------------- | :----: |
-| Number Input | `@zag-js/number-input` |   ⬜   |
-| Pin Input    | `@zag-js/pin-input`    |   ⬜   |
-| Slider       | `@zag-js/slider`       |   ⬜   |
-| Tags Input   | `@zag-js/tags-input`   |   ⬜   |
-| Editable     | `@zag-js/editable`     |   ⬜   |
-| Toggle Group | `@zag-js/toggle-group` |   ⬜   |
+| Number Input | `@zag-js/number-input` |   ✅   |
+| Pin Input    | `@zag-js/pin-input`    |   ✅   |
+| Slider       | `@zag-js/slider`       |   ✅   |
+| Tags Input   | `@zag-js/tags-input`   |   ✅   |
+| Editable     | `@zag-js/editable`     |   ✅   |
+| Toggle Group | `@zag-js/toggle-group` |   ✅   |
 
 ### Batch 4 — selection & data ⬜
 

--- a/packages/folds/package.json
+++ b/packages/folds/package.json
@@ -26,14 +26,20 @@
     "@zag-js/checkbox": "^1.41.2",
     "@zag-js/collapsible": "^1.41.2",
     "@zag-js/dialog": "^1.41.2",
+    "@zag-js/editable": "^1.41.2",
     "@zag-js/hover-card": "^1.41.2",
     "@zag-js/menu": "^1.41.2",
+    "@zag-js/number-input": "^1.41.2",
+    "@zag-js/pin-input": "^1.41.2",
     "@zag-js/popover": "^1.41.2",
     "@zag-js/radio-group": "^1.41.2",
+    "@zag-js/slider": "^1.41.2",
     "@zag-js/switch": "^1.41.2",
     "@zag-js/tabs": "^1.41.2",
+    "@zag-js/tags-input": "^1.41.2",
     "@zag-js/toast": "^1.41.2",
     "@zag-js/toggle": "^1.41.2",
+    "@zag-js/toggle-group": "^1.41.2",
     "@zag-js/tooltip": "^1.41.2"
   }
 }

--- a/packages/folds/src/index.ts
+++ b/packages/folds/src/index.ts
@@ -11,6 +11,12 @@ export * as popover from '@zag-js/popover';
 export * as hoverCard from '@zag-js/hover-card';
 export * as menu from '@zag-js/menu';
 export * as toast from '@zag-js/toast';
+export * as numberInput from '@zag-js/number-input';
+export * as pinInput from '@zag-js/pin-input';
+export * as slider from '@zag-js/slider';
+export * as tagsInput from '@zag-js/tags-input';
+export * as editable from '@zag-js/editable';
+export * as toggleGroup from '@zag-js/toggle-group';
 
 export const mantiBehaviorContract = {
   packageName: '@manti-ui/folds',

--- a/packages/react/src/components/Editable/Editable.stories.tsx
+++ b/packages/react/src/components/Editable/Editable.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Editable } from './Editable';
+
+const meta = {
+  title: 'Components/Editable',
+  component: Editable,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    label: 'Recipe name',
+    tone: 'primary',
+    defaultValue: 'Kayseri mantısı',
+    placeholder: 'Enter a name…',
+    activationMode: 'focus',
+    submitMode: 'both',
+    disabled: false,
+  },
+  argTypes: {
+    activationMode: {
+      control: 'inline-radio',
+      options: ['focus', 'dblclick', 'click', 'none'],
+    },
+    submitMode: {
+      control: 'inline-radio',
+      options: ['enter', 'blur', 'both', 'none'],
+    },
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof Editable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const DoubleClickToEdit: Story = {
+  args: { activationMode: 'dblclick' },
+};
+
+export const Empty: Story = {
+  args: { defaultValue: '', placeholder: 'Click to add a name…' },
+};

--- a/packages/react/src/components/Editable/Editable.tsx
+++ b/packages/react/src/components/Editable/Editable.tsx
@@ -1,0 +1,98 @@
+import { useId } from 'react';
+import type { ReactNode } from 'react';
+import { editable } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+
+export interface EditableProps {
+  /** Optional field label. */
+  label?: ReactNode;
+  /** Focus-ring tone. */
+  tone?: MantiTone;
+  /** Controlled value. */
+  value?: string;
+  /** Initial value for uncontrolled usage. */
+  defaultValue?: string;
+  /** Called whenever the value changes. */
+  onValueChange?: (value: string) => void;
+  /** Called when the value is committed (Enter/blur/submit). */
+  onValueCommit?: (value: string) => void;
+  /** What enters edit mode. */
+  activationMode?: 'focus' | 'dblclick' | 'click' | 'none';
+  /** What commits the value. */
+  submitMode?: 'enter' | 'blur' | 'both' | 'none';
+  placeholder?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  required?: boolean;
+  invalid?: boolean;
+  /** Form field name. */
+  name?: string;
+  id?: string;
+  className?: string;
+}
+
+/** An inline text field that toggles between preview and edit, backed by the
+ * Zag.js editable machine. */
+export function Editable({
+  label,
+  tone = 'primary',
+  value,
+  defaultValue,
+  onValueChange,
+  onValueCommit,
+  activationMode,
+  submitMode,
+  placeholder,
+  disabled,
+  readOnly,
+  required,
+  invalid,
+  name,
+  id,
+  className,
+}: EditableProps) {
+  const autoId = useId();
+  const service = useMachine(editable.machine, {
+    id: id ?? autoId,
+    value,
+    defaultValue,
+    activationMode,
+    submitMode,
+    placeholder,
+    disabled,
+    readOnly,
+    required,
+    invalid,
+    name,
+    onValueChange: onValueChange
+      ? (details) => onValueChange(details.value)
+      : undefined,
+    onValueCommit: onValueCommit
+      ? (details) => onValueCommit(details.value)
+      : undefined,
+  });
+  const api = editable.connect(service, normalizeProps);
+
+  return (
+    <div {...api.getRootProps()} data-tone={tone} className={cx(className)}>
+      {label != null && <label {...api.getLabelProps()}>{label}</label>}
+      <div {...api.getAreaProps()}>
+        <input {...api.getInputProps()} />
+        <span {...api.getPreviewProps()} />
+      </div>
+      <div {...api.getControlProps()}>
+        {api.editing ? (
+          <>
+            <button {...api.getSubmitTriggerProps()}>Save</button>
+            <button {...api.getCancelTriggerProps()}>Cancel</button>
+          </>
+        ) : (
+          <button {...api.getEditTriggerProps()}>Edit</button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { NumberInput } from './NumberInput';
+
+const meta = {
+  title: 'Components/NumberInput',
+  component: NumberInput,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    label: 'Servings',
+    size: 'md',
+    tone: 'primary',
+    defaultValue: '12',
+    min: 0,
+    max: 99,
+    step: 1,
+    disabled: false,
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof NumberInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div style={{ display: 'grid', gap: '1rem' }}>
+      <NumberInput {...args} size="sm" label="Small" />
+      <NumberInput {...args} size="md" label="Medium" />
+      <NumberInput {...args} size="lg" label="Large" />
+    </div>
+  ),
+};
+
+export const States: Story = {
+  render: (args) => (
+    <div style={{ display: 'grid', gap: '1rem' }}>
+      <NumberInput {...args} label="Default" />
+      <NumberInput {...args} label="Invalid" invalid />
+      <NumberInput {...args} label="Disabled" disabled />
+    </div>
+  ),
+};

--- a/packages/react/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.tsx
@@ -1,0 +1,115 @@
+import { useId } from 'react';
+import type { ReactNode } from 'react';
+import { numberInput } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+
+export interface NumberInputProps {
+  /** Optional field label. */
+  label?: ReactNode;
+  /** Control size. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Focus-ring tone. */
+  tone?: MantiTone;
+  /** Controlled value (string, mirroring the input). */
+  value?: string;
+  /** Initial value for uncontrolled usage. */
+  defaultValue?: string;
+  /** Called whenever the value changes. */
+  onValueChange?: (value: string, valueAsNumber: number) => void;
+  /** Minimum allowed value. */
+  min?: number;
+  /** Maximum allowed value. */
+  max?: number;
+  /** Increment/decrement step. */
+  step?: number;
+  /** Allow the mouse wheel to change the value while focused. */
+  allowMouseWheel?: boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  invalid?: boolean;
+  required?: boolean;
+  /** Form field name. */
+  name?: string;
+  id?: string;
+  className?: string;
+}
+
+/** A numeric stepper backed by the Zag.js number-input machine. */
+export function NumberInput({
+  label,
+  size = 'md',
+  tone = 'primary',
+  value,
+  defaultValue,
+  onValueChange,
+  min,
+  max,
+  step,
+  allowMouseWheel,
+  placeholder,
+  disabled,
+  readOnly,
+  invalid,
+  required,
+  name,
+  id,
+  className,
+}: NumberInputProps) {
+  const autoId = useId();
+  const service = useMachine(numberInput.machine, {
+    id: id ?? autoId,
+    value,
+    defaultValue,
+    min,
+    max,
+    step,
+    allowMouseWheel,
+    disabled,
+    readOnly,
+    invalid,
+    required,
+    name,
+    onValueChange: onValueChange
+      ? (details) => onValueChange(details.value, details.valueAsNumber)
+      : undefined,
+  });
+  const api = numberInput.connect(service, normalizeProps);
+
+  return (
+    <div
+      {...api.getRootProps()}
+      data-size={size}
+      data-tone={tone}
+      className={cx(className)}
+    >
+      {label != null && <label {...api.getLabelProps()}>{label}</label>}
+      <div {...api.getControlProps()}>
+        <button {...api.getDecrementTriggerProps()} aria-label="Decrement">
+          <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+            <path
+              d="M3 7h8"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+        <input {...api.getInputProps()} placeholder={placeholder} />
+        <button {...api.getIncrementTriggerProps()} aria-label="Increment">
+          <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+            <path
+              d="M7 3v8M3 7h8"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/PinInput/PinInput.stories.tsx
+++ b/packages/react/src/components/PinInput/PinInput.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { PinInput } from './PinInput';
+
+const meta = {
+  title: 'Components/PinInput',
+  component: PinInput,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    label: 'One-time code',
+    length: 4,
+    size: 'md',
+    tone: 'primary',
+    type: 'numeric',
+    otp: true,
+    mask: false,
+    disabled: false,
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    type: {
+      control: 'inline-radio',
+      options: ['numeric', 'alphanumeric', 'alphabetic'],
+    },
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof PinInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const SixDigits: Story = {
+  args: { length: 6, label: 'Verification code' },
+};
+
+export const Masked: Story = {
+  args: { mask: true, label: 'PIN' },
+};
+
+export const States: Story = {
+  render: (args) => (
+    <div style={{ display: 'grid', gap: '1rem' }}>
+      <PinInput {...args} label="Default" />
+      <PinInput {...args} label="Invalid" invalid />
+      <PinInput {...args} label="Disabled" disabled />
+    </div>
+  ),
+};

--- a/packages/react/src/components/PinInput/PinInput.tsx
+++ b/packages/react/src/components/PinInput/PinInput.tsx
@@ -1,0 +1,105 @@
+import { useId } from 'react';
+import type { ReactNode } from 'react';
+import { pinInput } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+
+export interface PinInputProps {
+  /** Number of input cells. */
+  length?: number;
+  /** Optional field label. */
+  label?: ReactNode;
+  /** Cell size. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Focus-ring tone. */
+  tone?: MantiTone;
+  /** Allowed character type. */
+  type?: 'alphanumeric' | 'numeric' | 'alphabetic';
+  /** Mask entered characters like a password field. */
+  mask?: boolean;
+  /** Hint the field is a one-time code (sets autocomplete). */
+  otp?: boolean;
+  /** Controlled value. */
+  value?: string[];
+  /** Initial value for uncontrolled usage. */
+  defaultValue?: string[];
+  /** Called on every change. */
+  onValueChange?: (value: string[]) => void;
+  /** Called once every cell is filled. */
+  onValueComplete?: (value: string[], valueAsString: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  invalid?: boolean;
+  required?: boolean;
+  /** Form field name. */
+  name?: string;
+  id?: string;
+  className?: string;
+}
+
+/** A segmented code entry backed by the Zag.js pin-input machine. */
+export function PinInput({
+  length = 4,
+  label,
+  size = 'md',
+  tone = 'primary',
+  type,
+  mask,
+  otp,
+  value,
+  defaultValue,
+  onValueChange,
+  onValueComplete,
+  placeholder,
+  disabled,
+  readOnly,
+  invalid,
+  required,
+  name,
+  id,
+  className,
+}: PinInputProps) {
+  const autoId = useId();
+  const service = useMachine(pinInput.machine, {
+    id: id ?? autoId,
+    count: length,
+    type,
+    mask,
+    otp,
+    value,
+    defaultValue,
+    placeholder,
+    disabled,
+    readOnly,
+    invalid,
+    required,
+    name,
+    onValueChange: onValueChange
+      ? (details) => onValueChange(details.value)
+      : undefined,
+    onValueComplete: onValueComplete
+      ? (details) => onValueComplete(details.value, details.valueAsString)
+      : undefined,
+  });
+  const api = pinInput.connect(service, normalizeProps);
+
+  return (
+    <div
+      {...api.getRootProps()}
+      data-size={size}
+      data-tone={tone}
+      className={cx(className)}
+    >
+      {label != null && <label {...api.getLabelProps()}>{label}</label>}
+      <div {...api.getControlProps()}>
+        {api.items.map((index) => (
+          <input key={index} {...api.getInputProps({ index })} />
+        ))}
+      </div>
+      <input {...api.getHiddenInputProps()} />
+    </div>
+  );
+}

--- a/packages/react/src/components/Slider/Slider.stories.tsx
+++ b/packages/react/src/components/Slider/Slider.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Slider } from './Slider';
+
+const meta = {
+  title: 'Components/Slider',
+  component: Slider,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  args: {
+    label: 'Spice level',
+    tone: 'primary',
+    defaultValue: 40,
+    min: 0,
+    max: 100,
+    step: 1,
+    showValue: true,
+    disabled: false,
+  },
+  argTypes: {
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof Slider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Range: Story = {
+  args: { label: 'Price range', defaultValue: [25, 75] },
+};
+
+export const WithMarks: Story = {
+  args: { label: 'Portion', marks: [0, 25, 50, 75, 100] },
+};
+
+export const Tones: Story = {
+  render: (args) => (
+    <div style={{ display: 'grid', gap: '1.5rem', maxWidth: 360 }}>
+      {(['primary', 'success', 'warning', 'danger', 'info'] as const).map(
+        (tone) => (
+          <Slider {...args} key={tone} tone={tone} label={tone} />
+        ),
+      )}
+    </div>
+  ),
+};

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -1,0 +1,119 @@
+import { useId } from 'react';
+import type { ReactNode } from 'react';
+import { slider } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+
+const toArray = (value: number | number[] | undefined): number[] | undefined =>
+  value == null ? undefined : Array.isArray(value) ? value : [value];
+
+export interface SliderProps {
+  /** Optional label. */
+  label?: ReactNode;
+  /** Filled-track tone. */
+  tone?: MantiTone;
+  /** Controlled value. Pass an array for a range slider. */
+  value?: number | number[];
+  /** Initial value for uncontrolled usage. */
+  defaultValue?: number | number[];
+  /** Called whenever the value changes. */
+  onValueChange?: (value: number[]) => void;
+  /** Called when a drag/keyboard interaction settles. */
+  onValueChangeEnd?: (value: number[]) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  orientation?: 'horizontal' | 'vertical';
+  /** Tick marks rendered along the track. */
+  marks?: number[];
+  /** Show the current value next to the label. */
+  showValue?: boolean;
+  disabled?: boolean;
+  readOnly?: boolean;
+  invalid?: boolean;
+  /** Form field name. */
+  name?: string;
+  id?: string;
+  className?: string;
+}
+
+/** A draggable value selector backed by the Zag.js slider machine. */
+export function Slider({
+  label,
+  tone = 'primary',
+  value,
+  defaultValue,
+  onValueChange,
+  onValueChangeEnd,
+  min,
+  max,
+  step,
+  orientation,
+  marks,
+  showValue,
+  disabled,
+  readOnly,
+  invalid,
+  name,
+  id,
+  className,
+}: SliderProps) {
+  const autoId = useId();
+  const service = useMachine(slider.machine, {
+    id: id ?? autoId,
+    value: toArray(value),
+    defaultValue: toArray(defaultValue) ?? [min ?? 0],
+    min,
+    max,
+    step,
+    orientation,
+    disabled,
+    readOnly,
+    invalid,
+    name,
+    onValueChange: onValueChange
+      ? (details) => onValueChange(details.value)
+      : undefined,
+    onValueChangeEnd: onValueChangeEnd
+      ? (details) => onValueChangeEnd(details.value)
+      : undefined,
+  });
+  const api = slider.connect(service, normalizeProps);
+
+  return (
+    <div {...api.getRootProps()} data-tone={tone} className={cx(className)}>
+      {(label != null || showValue) && (
+        <div data-part="header">
+          {label != null && <label {...api.getLabelProps()}>{label}</label>}
+          {showValue && (
+            <output {...api.getValueTextProps()}>
+              {api.value.join(' – ')}
+            </output>
+          )}
+        </div>
+      )}
+      <div {...api.getControlProps()}>
+        <div {...api.getTrackProps()}>
+          <div {...api.getRangeProps()} />
+        </div>
+        {api.value.map((_, index) => (
+          <div key={index} {...api.getThumbProps({ index })}>
+            <input {...api.getHiddenInputProps({ index })} />
+          </div>
+        ))}
+        {marks != null && marks.length > 0 && (
+          <div {...api.getMarkerGroupProps()}>
+            {marks.map((markValue) => (
+              <span
+                key={markValue}
+                {...api.getMarkerProps({ value: markValue })}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/TagsInput/TagsInput.stories.tsx
+++ b/packages/react/src/components/TagsInput/TagsInput.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TagsInput } from './TagsInput';
+
+const meta = {
+  title: 'Components/TagsInput',
+  component: TagsInput,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  args: {
+    label: 'Fillings',
+    tone: 'primary',
+    defaultValue: ['lamb', 'onion', 'pepper'],
+    placeholder: 'Add a filling…',
+    disabled: false,
+  },
+  argTypes: {
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof TagsInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const States: Story = {
+  render: (args) => (
+    <div style={{ display: 'grid', gap: '1rem', maxWidth: 420 }}>
+      <TagsInput {...args} label="Default" />
+      <TagsInput {...args} label="Invalid" invalid />
+      <TagsInput {...args} label="Disabled" disabled />
+    </div>
+  ),
+};
+
+export const MaxThree: Story = {
+  args: { label: 'Up to 3 tags', max: 3, defaultValue: ['lamb', 'onion'] },
+};

--- a/packages/react/src/components/TagsInput/TagsInput.tsx
+++ b/packages/react/src/components/TagsInput/TagsInput.tsx
@@ -1,0 +1,115 @@
+import { useId } from 'react';
+import type { ReactNode } from 'react';
+import { tagsInput } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+
+export interface TagsInputProps {
+  /** Optional field label. */
+  label?: ReactNode;
+  /** Focus-ring tone. */
+  tone?: MantiTone;
+  /** Controlled tag values. */
+  value?: string[];
+  /** Initial tag values for uncontrolled usage. */
+  defaultValue?: string[];
+  /** Called whenever the tag set changes. */
+  onValueChange?: (value: string[]) => void;
+  /** Maximum number of tags. */
+  max?: number;
+  /** Allow duplicate tags. */
+  allowDuplicates?: boolean;
+  /** Add a tag when pasting delimited text. */
+  addOnPaste?: boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  invalid?: boolean;
+  required?: boolean;
+  /** Form field name. */
+  name?: string;
+  id?: string;
+  className?: string;
+}
+
+/** A multi-value entry field backed by the Zag.js tags-input machine. */
+export function TagsInput({
+  label,
+  tone = 'primary',
+  value,
+  defaultValue,
+  onValueChange,
+  max,
+  allowDuplicates,
+  addOnPaste,
+  placeholder,
+  disabled,
+  readOnly,
+  invalid,
+  required,
+  name,
+  id,
+  className,
+}: TagsInputProps) {
+  const autoId = useId();
+  const service = useMachine(tagsInput.machine, {
+    id: id ?? autoId,
+    value,
+    defaultValue,
+    max,
+    allowDuplicates,
+    addOnPaste,
+    disabled,
+    readOnly,
+    invalid,
+    required,
+    name,
+    onValueChange: onValueChange
+      ? (details) => onValueChange(details.value)
+      : undefined,
+  });
+  const api = tagsInput.connect(service, normalizeProps);
+
+  return (
+    <div {...api.getRootProps()} data-tone={tone} className={cx(className)}>
+      {label != null && <label {...api.getLabelProps()}>{label}</label>}
+      <div {...api.getControlProps()}>
+        {api.value.map((tag, index) => (
+          <span
+            key={`${tag}-${index}`}
+            {...api.getItemProps({ index, value: tag })}
+          >
+            <span {...api.getItemPreviewProps({ index, value: tag })}>
+              <span {...api.getItemTextProps({ index, value: tag })}>
+                {tag}
+              </span>
+              <button
+                {...api.getItemDeleteTriggerProps({ index, value: tag })}
+                aria-label={`Remove ${tag}`}
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M3 3l6 6M9 3l-6 6"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            </span>
+            <input {...api.getItemInputProps({ index, value: tag })} />
+          </span>
+        ))}
+        <input {...api.getInputProps()} placeholder={placeholder} />
+      </div>
+      <input {...api.getHiddenInputProps()} />
+    </div>
+  );
+}

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ToggleGroup } from './ToggleGroup';
+
+const alignItems = [
+  { value: 'left', label: 'Left' },
+  { value: 'center', label: 'Center' },
+  { value: 'right', label: 'Right' },
+];
+
+const meta = {
+  title: 'Components/ToggleGroup',
+  component: ToggleGroup,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    items: alignItems,
+    size: 'md',
+    tone: 'primary',
+    multiple: false,
+    defaultValue: ['center'],
+    orientation: 'horizontal',
+    disabled: false,
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    orientation: {
+      control: 'inline-radio',
+      options: ['horizontal', 'vertical'],
+    },
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof ToggleGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Multiple: Story = {
+  args: {
+    multiple: true,
+    defaultValue: ['left', 'right'],
+    items: [
+      { value: 'bold', label: 'B' },
+      { value: 'italic', label: 'I' },
+      { value: 'underline', label: 'U' },
+    ],
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div style={{ display: 'grid', gap: '1rem', justifyItems: 'start' }}>
+      <ToggleGroup {...args} size="sm" />
+      <ToggleGroup {...args} size="md" />
+      <ToggleGroup {...args} size="lg" />
+    </div>
+  ),
+};

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
@@ -1,0 +1,81 @@
+import { useId } from 'react';
+import type { ReactNode } from 'react';
+import { toggleGroup } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+
+export interface ToggleGroupItem {
+  value: string;
+  label: ReactNode;
+  disabled?: boolean;
+}
+
+export interface ToggleGroupProps {
+  /** The options. */
+  items: ToggleGroupItem[];
+  /** Control size. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Active tone for pressed items. */
+  tone?: MantiTone;
+  /** Allow more than one item to be pressed at once. */
+  multiple?: boolean;
+  /** Controlled pressed values. */
+  value?: string[];
+  /** Initial pressed values for uncontrolled usage. */
+  defaultValue?: string[];
+  /** Called whenever the pressed set changes. */
+  onValueChange?: (value: string[]) => void;
+  orientation?: 'horizontal' | 'vertical';
+  disabled?: boolean;
+  id?: string;
+  className?: string;
+}
+
+/** A set of toggle buttons backed by the Zag.js toggle-group machine. */
+export function ToggleGroup({
+  items,
+  size = 'md',
+  tone = 'primary',
+  multiple,
+  value,
+  defaultValue,
+  onValueChange,
+  orientation,
+  disabled,
+  id,
+  className,
+}: ToggleGroupProps) {
+  const autoId = useId();
+  const service = useMachine(toggleGroup.machine, {
+    id: id ?? autoId,
+    multiple,
+    value,
+    defaultValue,
+    orientation,
+    disabled,
+    onValueChange: onValueChange
+      ? (details) => onValueChange(details.value)
+      : undefined,
+  });
+  const api = toggleGroup.connect(service, normalizeProps);
+
+  return (
+    <div
+      {...api.getRootProps()}
+      data-size={size}
+      data-tone={tone}
+      className={cx(className)}
+    >
+      {items.map((item) => (
+        <button
+          key={item.value}
+          {...api.getItemProps({ value: item.value, disabled: item.disabled })}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -22,6 +22,9 @@ export type { CollapsibleProps } from './Collapsible/Collapsible';
 export { Dialog } from './Dialog/Dialog';
 export type { DialogProps, DialogSize } from './Dialog/Dialog';
 
+export { Editable } from './Editable/Editable';
+export type { EditableProps } from './Editable/Editable';
+
 export { HoverCard } from './HoverCard/HoverCard';
 export type { HoverCardProps } from './HoverCard/HoverCard';
 
@@ -34,11 +37,20 @@ export type {
   MenuSeparator,
 } from './Menu/Menu';
 
+export { NumberInput } from './NumberInput/NumberInput';
+export type { NumberInputProps } from './NumberInput/NumberInput';
+
+export { PinInput } from './PinInput/PinInput';
+export type { PinInputProps } from './PinInput/PinInput';
+
 export { Popover } from './Popover/Popover';
 export type { PopoverProps } from './Popover/Popover';
 
 export { RadioGroup } from './RadioGroup/RadioGroup';
 export type { RadioGroupItem, RadioGroupProps } from './RadioGroup/RadioGroup';
+
+export { Slider } from './Slider/Slider';
+export type { SliderProps } from './Slider/Slider';
 
 export { Spinner } from './Spinner/Spinner';
 export type { SpinnerProps } from './Spinner/Spinner';
@@ -48,6 +60,9 @@ export type { SwitchProps } from './Switch/Switch';
 
 export { Tabs } from './Tabs/Tabs';
 export type { TabItem, TabsProps } from './Tabs/Tabs';
+
+export { TagsInput } from './TagsInput/TagsInput';
+export type { TagsInputProps } from './TagsInput/TagsInput';
 
 export { createToaster } from './Toast/Toast';
 export type {
@@ -63,6 +78,12 @@ export type { TextFieldProps } from './TextField/TextField';
 
 export { Toggle } from './Toggle/Toggle';
 export type { ToggleProps } from './Toggle/Toggle';
+
+export { ToggleGroup } from './ToggleGroup/ToggleGroup';
+export type {
+  ToggleGroupItem,
+  ToggleGroupProps,
+} from './ToggleGroup/ToggleGroup';
 
 export { Tooltip } from './Tooltip/Tooltip';
 export type { TooltipProps } from './Tooltip/Tooltip';

--- a/packages/styles/src/components/editable.css
+++ b/packages/styles/src/components/editable.css
@@ -1,0 +1,129 @@
+/**
+ * Editable — an inline text field that toggles between a preview and an input,
+ * backed by the Zag.js editable machine. Preview reads as plain text with a
+ * hover affordance; edit mode shows the frosted field input plus triggers.
+ */
+@layer manti.components {
+  [data-scope='editable'][data-part='root'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-2);
+    min-width: 0;
+  }
+
+  [data-scope='editable'][data-part='label'] {
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    color: var(--manti-text);
+  }
+
+  [data-scope='editable'][data-part='area'] {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.5rem;
+  }
+
+  [data-scope='editable'][data-part='preview'] {
+    padding: var(--manti-space-2) var(--manti-space-3);
+    border: 1px solid transparent;
+    border-radius: var(--manti-radius-md);
+    color: var(--manti-text);
+    font-size: var(--manti-text-sm);
+    cursor: text;
+    transition: background-color var(--manti-duration-fast)
+      var(--manti-ease-smooth);
+
+    &:hover {
+      background: color-mix(
+        in oklab,
+        var(--manti-surface-raised) 70%,
+        transparent
+      );
+    }
+
+    &[data-empty] {
+      color: var(--manti-text-subtle);
+    }
+  }
+
+  [data-scope='editable'][data-part='input'] {
+    min-width: 0;
+    padding: var(--manti-space-2) var(--manti-space-3);
+    background: var(--manti-glass-tint-strong);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    outline: none;
+    color: var(--manti-text);
+    font-size: var(--manti-text-sm);
+    box-shadow: inset 0 1px 0 0 var(--manti-glass-highlight);
+    transition:
+      border-color var(--manti-duration-base) var(--manti-ease-smooth),
+      box-shadow var(--manti-duration-base) var(--manti-ease-smooth);
+
+    &:focus {
+      border-color: var(--tone-ring, var(--manti-focus-ring));
+      box-shadow:
+        inset 0 1px 0 0 var(--manti-glass-highlight),
+        0 0 0 3px
+          color-mix(
+            in oklab,
+            var(--tone-ring, var(--manti-focus-ring)) 30%,
+            transparent
+          );
+    }
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='editable'][data-part='input'] {
+      background: var(--manti-surface-raised);
+    }
+  }
+
+  [data-scope='editable'][data-part='control'] {
+    display: inline-flex;
+    gap: var(--manti-space-2);
+  }
+
+  [data-scope='editable'][data-part='edit-trigger'],
+  [data-scope='editable'][data-part='submit-trigger'],
+  [data-scope='editable'][data-part='cancel-trigger'] {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding-inline: var(--manti-space-3);
+    border: 1px solid var(--tone-border);
+    border-radius: var(--manti-radius-sm);
+    color: var(--tone-text);
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    cursor: pointer;
+    transition:
+      background-color var(--manti-duration-fast) var(--manti-ease-smooth),
+      border-color var(--manti-duration-fast) var(--manti-ease-smooth);
+
+    &:hover {
+      background: color-mix(in oklab, var(--tone-soft-bg) 60%, transparent);
+      border-color: var(--tone-soft-text);
+    }
+
+    &:focus-visible {
+      outline: var(--manti-focus-ring-width) solid var(--tone-ring);
+      outline-offset: var(--manti-focus-ring-offset);
+    }
+  }
+
+  [data-scope='editable'][data-part='submit-trigger'] {
+    background: var(--tone-solid);
+    border-color: transparent;
+    color: var(--tone-on-solid);
+
+    &:hover {
+      background: var(--tone-solid-hover);
+      border-color: transparent;
+    }
+  }
+}

--- a/packages/styles/src/components/number-input.css
+++ b/packages/styles/src/components/number-input.css
@@ -1,0 +1,137 @@
+/**
+ * Number Input — a numeric stepper backed by the Zag.js number-input machine.
+ * The control wraps decrement/input/increment in the shared frosted field
+ * surface; state (`data-disabled`, `data-invalid`, `data-focus`) comes from the
+ * machine.
+ */
+@layer manti.components {
+  [data-scope='number-input'][data-part='root'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-2);
+    min-width: 0;
+  }
+
+  [data-scope='number-input'][data-part='label'] {
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    color: var(--manti-text);
+  }
+
+  [data-scope='number-input'][data-part='control'] {
+    --_min-height: 2.5rem;
+
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: stretch;
+    min-height: var(--_min-height);
+    background: var(--manti-glass-tint-strong);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    box-shadow:
+      inset 0 1px 0 0 var(--manti-glass-highlight),
+      inset 0 2px 5px -3px var(--manti-glass-shadow-color);
+    transition:
+      border-color var(--manti-duration-base) var(--manti-ease-smooth),
+      box-shadow var(--manti-duration-base) var(--manti-ease-smooth);
+
+    &:hover {
+      border-color: var(--manti-text-subtle);
+    }
+
+    &:focus-within {
+      border-color: var(--tone-ring, var(--manti-focus-ring));
+      box-shadow:
+        inset 0 1px 0 0 var(--manti-glass-highlight),
+        0 0 0 3px
+          color-mix(
+            in oklab,
+            var(--tone-ring, var(--manti-focus-ring)) 30%,
+            transparent
+          );
+    }
+  }
+
+  [data-scope='number-input'][data-part='root'][data-size='sm']
+    [data-part='control'] {
+    --_min-height: 2rem;
+  }
+
+  [data-scope='number-input'][data-part='root'][data-size='lg']
+    [data-part='control'] {
+    --_min-height: 3rem;
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='number-input'][data-part='control'] {
+      background: var(--manti-surface-raised);
+    }
+  }
+
+  [data-scope='number-input'][data-part='root'][data-invalid]
+    [data-part='control'] {
+    border-color: light-dark(var(--manti-chili-500), var(--manti-chili-400));
+  }
+
+  [data-scope='number-input'][data-part='root'][data-disabled]
+    [data-part='control'] {
+    background: var(--manti-surface-sunken);
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  [data-scope='number-input'][data-part='input'] {
+    min-width: 0;
+    background: none;
+    border: none;
+    outline: none;
+    text-align: center;
+    color: var(--manti-text);
+    font-size: var(--manti-text-sm);
+    font-variant-numeric: tabular-nums;
+
+    &::placeholder {
+      color: var(--manti-text-subtle);
+    }
+  }
+
+  [data-scope='number-input'][data-part='decrement-trigger'],
+  [data-scope='number-input'][data-part='increment-trigger'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    color: var(--manti-text-muted);
+    cursor: pointer;
+    transition:
+      background-color var(--manti-duration-fast) var(--manti-ease-smooth),
+      color var(--manti-duration-fast) var(--manti-ease-smooth);
+
+    &:hover {
+      background: color-mix(in oklab, var(--tone-soft-bg) 60%, transparent);
+      color: var(--tone-soft-text);
+    }
+
+    &[data-disabled] {
+      color: var(--manti-text-subtle);
+      cursor: not-allowed;
+      background: none;
+    }
+  }
+
+  [data-scope='number-input'][data-part='decrement-trigger'] {
+    border-inline-end: 1px solid var(--manti-glass-border);
+    border-start-start-radius: var(--manti-radius-md);
+    border-end-start-radius: var(--manti-radius-md);
+  }
+
+  [data-scope='number-input'][data-part='increment-trigger'] {
+    border-inline-start: 1px solid var(--manti-glass-border);
+    border-start-end-radius: var(--manti-radius-md);
+    border-end-end-radius: var(--manti-radius-md);
+  }
+}

--- a/packages/styles/src/components/pin-input.css
+++ b/packages/styles/src/components/pin-input.css
@@ -1,0 +1,93 @@
+/**
+ * Pin Input — segmented code entry backed by the Zag.js pin-input machine. Each
+ * cell is a frosted field box; the focused cell rings with the active tone.
+ */
+@layer manti.components {
+  [data-scope='pin-input'][data-part='root'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-2);
+  }
+
+  [data-scope='pin-input'][data-part='label'] {
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    color: var(--manti-text);
+  }
+
+  [data-scope='pin-input'][data-part='control'] {
+    display: flex;
+    gap: var(--manti-space-2);
+  }
+
+  [data-scope='pin-input'][data-part='input'] {
+    --_size: 2.75rem;
+
+    width: var(--_size);
+    height: var(--_size);
+    padding: 0;
+    background: var(--manti-glass-tint-strong);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    box-shadow:
+      inset 0 1px 0 0 var(--manti-glass-highlight),
+      inset 0 2px 5px -3px var(--manti-glass-shadow-color);
+    outline: none;
+    text-align: center;
+    color: var(--manti-text);
+    font-size: var(--manti-text-lg);
+    font-weight: var(--manti-weight-semibold);
+    font-variant-numeric: tabular-nums;
+    transition:
+      border-color var(--manti-duration-base) var(--manti-ease-smooth),
+      box-shadow var(--manti-duration-base) var(--manti-ease-smooth);
+
+    &:hover {
+      border-color: var(--manti-text-subtle);
+    }
+
+    &:focus {
+      border-color: var(--tone-ring, var(--manti-focus-ring));
+      box-shadow:
+        inset 0 1px 0 0 var(--manti-glass-highlight),
+        0 0 0 3px
+          color-mix(
+            in oklab,
+            var(--tone-ring, var(--manti-focus-ring)) 30%,
+            transparent
+          );
+    }
+
+    &:disabled {
+      background: var(--manti-surface-sunken);
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='pin-input'][data-part='input'] {
+      background: var(--manti-surface-raised);
+    }
+  }
+
+  [data-scope='pin-input'][data-part='root'][data-size='sm']
+    [data-part='input'] {
+    --_size: 2.25rem;
+    font-size: var(--manti-text-base);
+  }
+
+  [data-scope='pin-input'][data-part='root'][data-size='lg']
+    [data-part='input'] {
+    --_size: 3.25rem;
+    font-size: var(--manti-text-xl);
+  }
+
+  [data-scope='pin-input'][data-part='root'][data-invalid] [data-part='input'] {
+    border-color: light-dark(var(--manti-chili-500), var(--manti-chili-400));
+  }
+}

--- a/packages/styles/src/components/slider.css
+++ b/packages/styles/src/components/slider.css
@@ -1,0 +1,122 @@
+/**
+ * Slider — a draggable value selector backed by the Zag.js slider machine. Zag
+ * positions the track/range/thumbs inline; this file owns appearance. Works for
+ * single and range (multi-thumb) sliders, horizontal and vertical.
+ */
+@layer manti.components {
+  [data-scope='slider'][data-part='root'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-3);
+
+    & [data-part='header'] {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--manti-space-3);
+    }
+  }
+
+  [data-scope='slider'][data-part='label'] {
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    color: var(--manti-text);
+  }
+
+  [data-scope='slider'][data-part='value-text'] {
+    font-size: var(--manti-text-sm);
+    color: var(--manti-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  [data-scope='slider'][data-part='control'] {
+    --_thumb: 1.125rem;
+    --_track: 0.375rem;
+
+    position: relative;
+    display: flex;
+    align-items: center;
+
+    &[data-orientation='horizontal'] {
+      min-height: var(--_thumb);
+    }
+
+    &[data-orientation='vertical'] {
+      flex-direction: column;
+      width: var(--_thumb);
+      height: 12rem;
+    }
+  }
+
+  [data-scope='slider'][data-part='track'] {
+    background: var(--manti-border-strong);
+    border-radius: var(--manti-radius-full);
+
+    [data-orientation='horizontal'] & {
+      height: var(--_track);
+      width: 100%;
+    }
+
+    [data-orientation='vertical'] & {
+      width: var(--_track);
+      height: 100%;
+    }
+  }
+
+  [data-scope='slider'][data-part='range'] {
+    background: var(--tone-solid);
+    border-radius: var(--manti-radius-full);
+
+    [data-orientation='horizontal'] & {
+      height: 100%;
+    }
+
+    [data-orientation='vertical'] & {
+      width: 100%;
+    }
+  }
+
+  [data-scope='slider'][data-part='root'][data-disabled] [data-part='range'] {
+    background: var(--manti-text-subtle);
+  }
+
+  [data-scope='slider'][data-part='thumb'] {
+    width: var(--_thumb);
+    height: var(--_thumb);
+    background: var(--manti-surface-raised);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-full);
+    box-shadow: var(--manti-shadow-sm);
+    cursor: grab;
+    transition:
+      box-shadow var(--manti-duration-fast) var(--manti-ease-smooth),
+      transform var(--manti-duration-fast) var(--manti-ease-smooth);
+
+    &[data-dragging] {
+      cursor: grabbing;
+      transform: scale(1.1);
+    }
+
+    &:focus-visible {
+      outline: var(--manti-focus-ring-width) solid var(--tone-ring);
+      outline-offset: var(--manti-focus-ring-offset);
+    }
+  }
+
+  [data-scope='slider'][data-part='root'][data-disabled] [data-part='thumb'] {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  [data-scope='slider'][data-part='marker-group'] {
+    position: absolute;
+    inset: 0;
+  }
+
+  [data-scope='slider'][data-part='marker'] {
+    width: 0.25rem;
+    height: 0.25rem;
+    background: var(--manti-text-subtle);
+    border-radius: var(--manti-radius-full);
+  }
+}

--- a/packages/styles/src/components/tags-input.css
+++ b/packages/styles/src/components/tags-input.css
@@ -1,0 +1,125 @@
+/**
+ * Tags Input — a multi-value entry field backed by the Zag.js tags-input
+ * machine. Tags are tonal soft pills inside the shared frosted field surface;
+ * the entry input flows after the last tag and wraps as needed.
+ */
+@layer manti.components {
+  [data-scope='tags-input'][data-part='root'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-2);
+    min-width: 0;
+  }
+
+  [data-scope='tags-input'][data-part='label'] {
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    color: var(--manti-text);
+  }
+
+  [data-scope='tags-input'][data-part='control'] {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--manti-space-2);
+    min-height: 2.5rem;
+    padding: var(--manti-space-2) var(--manti-space-3);
+    background: var(--manti-glass-tint-strong);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    box-shadow:
+      inset 0 1px 0 0 var(--manti-glass-highlight),
+      inset 0 2px 5px -3px var(--manti-glass-shadow-color);
+    transition:
+      border-color var(--manti-duration-base) var(--manti-ease-smooth),
+      box-shadow var(--manti-duration-base) var(--manti-ease-smooth);
+
+    &:focus-within {
+      border-color: var(--tone-ring, var(--manti-focus-ring));
+      box-shadow:
+        inset 0 1px 0 0 var(--manti-glass-highlight),
+        0 0 0 3px
+          color-mix(
+            in oklab,
+            var(--tone-ring, var(--manti-focus-ring)) 30%,
+            transparent
+          );
+    }
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='tags-input'][data-part='control'] {
+      background: var(--manti-surface-raised);
+    }
+  }
+
+  [data-scope='tags-input'][data-part='root'][data-invalid]
+    [data-part='control'] {
+    border-color: light-dark(var(--manti-chili-500), var(--manti-chili-400));
+  }
+
+  [data-scope='tags-input'][data-part='root'][data-disabled]
+    [data-part='control'] {
+    background: var(--manti-surface-sunken);
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  [data-scope='tags-input'][data-part='item-preview'] {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--manti-space-1);
+    height: 1.625rem;
+    padding-inline: var(--manti-space-2);
+    background: color-mix(in oklab, var(--tone-soft-bg) 80%, transparent);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-sm);
+    color: var(--tone-soft-text);
+    font-size: var(--manti-text-xs);
+    font-weight: var(--manti-weight-medium);
+
+    &[data-highlighted] {
+      background: var(--tone-soft-bg-hover);
+    }
+  }
+
+  [data-scope='tags-input'][data-part='item-delete-trigger'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: currentcolor;
+    opacity: 0.7;
+    cursor: pointer;
+    transition: opacity var(--manti-duration-fast) var(--manti-ease-smooth);
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  [data-scope='tags-input'][data-part='item-input'] {
+    background: none;
+    border: none;
+    outline: none;
+    color: var(--manti-text);
+    font-size: var(--manti-text-xs);
+  }
+
+  [data-scope='tags-input'][data-part='input'] {
+    flex: 1;
+    min-width: 6ch;
+    background: none;
+    border: none;
+    outline: none;
+    color: var(--manti-text);
+    font-size: var(--manti-text-sm);
+
+    &::placeholder {
+      color: var(--manti-text-subtle);
+    }
+  }
+}

--- a/packages/styles/src/components/toggle-group.css
+++ b/packages/styles/src/components/toggle-group.css
@@ -1,0 +1,102 @@
+/**
+ * Toggle Group — a segmented set of toggle buttons backed by the Zag.js
+ * toggle-group machine. Items sit in a shared frosted container; the pressed
+ * item (`data-state='on'`) fills with the active tone.
+ */
+@layer manti.components {
+  [data-scope='toggle-group'][data-part='root'] {
+    display: inline-flex;
+    padding: var(--manti-space-1);
+    gap: var(--manti-space-1);
+    background: var(--manti-glass-tint);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    box-shadow: inset 0 1px 0 0 var(--manti-glass-highlight);
+
+    &[data-orientation='vertical'] {
+      flex-direction: column;
+    }
+
+    &[data-disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='toggle-group'][data-part='root'] {
+      background: var(--manti-surface);
+    }
+  }
+
+  [data-scope='toggle-group'][data-part='item'] {
+    --_min-height: 2rem;
+    --_px: var(--manti-space-3);
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--manti-space-2);
+    min-width: var(--_min-height);
+    min-height: var(--_min-height);
+    padding-inline: var(--_px);
+    border: 1px solid transparent;
+    border-radius: var(--manti-radius-sm);
+    color: var(--manti-text-muted);
+    font-family: var(--manti-font-sans);
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-semibold);
+    cursor: pointer;
+    transition:
+      background-color var(--manti-duration-fast) var(--manti-ease-smooth),
+      color var(--manti-duration-fast) var(--manti-ease-smooth),
+      transform var(--manti-duration-fast) var(--manti-ease-smooth);
+
+    &:hover {
+      background: color-mix(in oklab, var(--tone-soft-bg) 60%, transparent);
+      color: var(--tone-soft-text);
+    }
+
+    &[data-state='on'] {
+      background: var(--tone-solid);
+      color: var(--tone-on-solid);
+      box-shadow: var(--manti-shadow-sm);
+
+      &:hover {
+        background: var(--tone-solid-hover);
+      }
+    }
+
+    &:active {
+      transform: scale(0.97);
+    }
+
+    &:focus-visible {
+      outline: var(--manti-focus-ring-width) solid var(--tone-ring);
+      outline-offset: var(--manti-focus-ring-offset);
+    }
+
+    &[data-disabled] {
+      color: var(--manti-text-subtle);
+      cursor: not-allowed;
+    }
+  }
+
+  [data-scope='toggle-group'][data-part='root'][data-size='sm']
+    [data-part='item'] {
+    --_min-height: 1.75rem;
+    --_px: var(--manti-space-2);
+    font-size: var(--manti-text-xs);
+  }
+
+  [data-scope='toggle-group'][data-part='root'][data-size='lg']
+    [data-part='item'] {
+    --_min-height: 2.5rem;
+    --_px: var(--manti-space-4);
+    font-size: var(--manti-text-base);
+  }
+}

--- a/packages/styles/src/index.css
+++ b/packages/styles/src/index.css
@@ -29,6 +29,12 @@
 @import './components/hover-card.css';
 @import './components/menu.css';
 @import './components/toast.css';
+@import './components/number-input.css';
+@import './components/pin-input.css';
+@import './components/slider.css';
+@import './components/tags-input.css';
+@import './components/editable.css';
+@import './components/toggle-group.css';
 
 /* Motion tiers — declared last so [data-motion] overrides win by layer order.
    Import `none` after `full` so an inner [data-motion="none"] subtree reliably

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,10 +71,19 @@ importers:
       '@zag-js/dialog':
         specifier: ^1.41.2
         version: 1.41.2
+      '@zag-js/editable':
+        specifier: ^1.41.2
+        version: 1.41.2
       '@zag-js/hover-card':
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/menu':
+        specifier: ^1.41.2
+        version: 1.41.2
+      '@zag-js/number-input':
+        specifier: ^1.41.2
+        version: 1.41.2
+      '@zag-js/pin-input':
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/popover':
@@ -83,16 +92,25 @@ importers:
       '@zag-js/radio-group':
         specifier: ^1.41.2
         version: 1.41.2
+      '@zag-js/slider':
+        specifier: ^1.41.2
+        version: 1.41.2
       '@zag-js/switch':
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/tabs':
         specifier: ^1.41.2
         version: 1.41.2
+      '@zag-js/tags-input':
+        specifier: ^1.41.2
+        version: 1.41.2
       '@zag-js/toast':
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/toggle':
+        specifier: ^1.41.2
+        version: 1.41.2
+      '@zag-js/toggle-group':
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/tooltip':
@@ -443,6 +461,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@internationalized/number@3.6.6':
+    resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
@@ -910,6 +931,9 @@ packages:
       typescript:
         optional: true
 
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -1073,6 +1097,9 @@ packages:
   '@zag-js/aria-hidden@1.41.2':
     resolution: {integrity: sha512-qEcYmwlQr3qjA0T/IZ5a/o7fRUxfQ14tXjAFhR3GXCtxBKaqS+wnq/LN09Xw4bin3QWTINU+Z0oXFs9spWtNwA==}
 
+  '@zag-js/auto-resize@1.41.2':
+    resolution: {integrity: sha512-CYq+JQ1TTkEiK7OcNcMTS0f4wFvtmManvUltije5o50gDQ7vFYA81oQh4A9pAB1keUi9Zv06CNefFARaTcne5w==}
+
   '@zag-js/checkbox@1.41.2':
     resolution: {integrity: sha512-aQ5dZWHUHRIw4cbLtzrR+dc8M0N6wSiiCml/zbU3ciHOTBXSrs2rKnp/L99xhi97Lj2uCEhpIZ704Ou/MjGuCg==}
 
@@ -1091,6 +1118,9 @@ packages:
   '@zag-js/dom-query@1.41.2':
     resolution: {integrity: sha512-+eBk1nlJA312mNmY/GSThLRwcCRqMIL+A1pLsWvTlQLQjmH1/UxoAuv6l2yvRCT33XmC8FBlBIKnXhOCpDvIZA==}
 
+  '@zag-js/editable@1.41.2':
+    resolution: {integrity: sha512-loTM1lrHBBqYfR8SJZrYayVdWHMpXCLVir+aDTQ8/d4bb/Gfl/L8CJNs3BRj3yt9zvLoWTLO+4LOY3hLyQSR2w==}
+
   '@zag-js/focus-trap@1.41.2':
     resolution: {integrity: sha512-3QTtGUjFU2OLbyrDlyoYWvKZecCmtn/+bsfsHW159jJHiEGHVYK6CY8AI1ePsMk9gVay48bXh008j+lVli7gAw==}
 
@@ -1103,8 +1133,17 @@ packages:
   '@zag-js/interact-outside@1.41.2':
     resolution: {integrity: sha512-dM4Fn9iyqQeqkCMRYZP+bAgWEPKRVQRqMmcPsN0OXBhhFKC31Em15LTIZXaOtVKAjH+iwx+UvSYFRiWwEjkOEA==}
 
+  '@zag-js/live-region@1.41.2':
+    resolution: {integrity: sha512-7ubIW5AQt1wx9S/gFN+rU4TyvuFWJrL/DhnDWPNlH5g3luDVHSNeYGeeqf4d4tkcibtpYZa0pg9CbXxRxrfwVA==}
+
   '@zag-js/menu@1.41.2':
     resolution: {integrity: sha512-wwix8hcAUSi0scpWXCiDppfdZV01Za8nN0gqLt9GdhCiVSlr0rs9pK1ROgPKJTyc43UZfyFPqtTWVHvEHMM70w==}
+
+  '@zag-js/number-input@1.41.2':
+    resolution: {integrity: sha512-QoQWCiVHO+ciUbq8uL8Kxhtk4o3UpwzYpJkfsOfitzsZoYpPc7V/A6+n5yABV2SOwpqBODwNASZdxiEa60kfow==}
+
+  '@zag-js/pin-input@1.41.2':
+    resolution: {integrity: sha512-Wrn3YDbmWL3qvUIzN4QyLO7PzEhunX7z8DwBpmrK04p7HxR9pniTLVIPk27xk2MzyAPYcl4mwd9/Mc88tBxHsg==}
 
   '@zag-js/popover@1.41.2':
     resolution: {integrity: sha512-h/LlVMIERM+NWzYV0ZHURlJuaqkT8XxwyEV96XfVzjknDRFNoPSl5IttVYtoaPoUqC0p/Y4oTSiee4mUZKOLHw==}
@@ -1127,6 +1166,9 @@ packages:
   '@zag-js/remove-scroll@1.41.2':
     resolution: {integrity: sha512-ieIrOgPKlCikAGEBIboQJoU7oxrL5BEY670tDOu7Eg7rNOdAwGXLEKPX2A/q+lREhOiVYjx0D3//vHTvdte80Q==}
 
+  '@zag-js/slider@1.41.2':
+    resolution: {integrity: sha512-mKK2BwoDbIGxAdkdKkPZJA1SHtEQt3lS9hJ6WghefYU2vyd0BXoIKvcDV3xJOzly5LXYhH5cJITn6JtGK8353A==}
+
   '@zag-js/store@1.41.2':
     resolution: {integrity: sha512-dVZF7E1ezXzynrKhMH3rfSr2rBbCfvTjvXbXz7//1PNULuq58UU5dG93V+9l834npCZxI2+PrpY45wZLJPTsIA==}
 
@@ -1136,8 +1178,14 @@ packages:
   '@zag-js/tabs@1.41.2':
     resolution: {integrity: sha512-7YVj2mCcxRbn1wMXP9anaTOVf+J0fa5uaPScr8e4+e2xc+/1WKzqN6V8IDeKS5wV/xzi1r3Ny307sX7Xz4ZJVQ==}
 
+  '@zag-js/tags-input@1.41.2':
+    resolution: {integrity: sha512-aIPEndSO+9LHxyoXLUr0Uttxw2cYMyDuii5w50wn/N7lFJD49U3Sj+6XaB/oJSbDAwn10WrsRDtb7Gs2kmU+Qw==}
+
   '@zag-js/toast@1.41.2':
     resolution: {integrity: sha512-+F3PsAo6EIz4rh73IOMCb/+FOUp7e3VjUY2q5sdU4IbfOzJBIbVSJxn0PQmHkuxkzWdCom0Lv0qSPFg/UTplnQ==}
+
+  '@zag-js/toggle-group@1.41.2':
+    resolution: {integrity: sha512-C6wn3A89h24hTs0BN9ryEuKatfR493u7QqxS06TeK9oI/KZBvm5Rwm8FPHSUJvsUTkAkow4PsXC0Ra19duzEdQ==}
 
   '@zag-js/toggle@1.41.2':
     resolution: {integrity: sha512-EFB9pb3pEtwXt7RSivVLWXV64dKUF8gsn75tt8TbYBgfy+zW85MsRLu8U48TXZN5teQWAKKNujr9bxQsW/CWvQ==}
@@ -2211,6 +2259,10 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@internationalized/number@3.6.6':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.27.7))':
     dependencies:
       glob: 13.0.6
@@ -2544,6 +2596,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -2761,6 +2817,10 @@ snapshots:
     dependencies:
       '@zag-js/dom-query': 1.41.2
 
+  '@zag-js/auto-resize@1.41.2':
+    dependencies:
+      '@zag-js/dom-query': 1.41.2
+
   '@zag-js/checkbox@1.41.2':
     dependencies:
       '@zag-js/anatomy': 1.41.2
@@ -2805,6 +2865,15 @@ snapshots:
     dependencies:
       '@zag-js/types': 1.41.2
 
+  '@zag-js/editable@1.41.2':
+    dependencies:
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dom-query': 1.41.2
+      '@zag-js/interact-outside': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
   '@zag-js/focus-trap@1.41.2':
     dependencies:
       '@zag-js/dom-query': 1.41.2
@@ -2828,6 +2897,8 @@ snapshots:
       '@zag-js/dom-query': 1.41.2
       '@zag-js/utils': 1.41.2
 
+  '@zag-js/live-region@1.41.2': {}
+
   '@zag-js/menu@1.41.2':
     dependencies:
       '@zag-js/anatomy': 1.41.2
@@ -2837,6 +2908,23 @@ snapshots:
       '@zag-js/focus-visible': 1.41.2
       '@zag-js/popper': 1.41.2
       '@zag-js/rect-utils': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
+  '@zag-js/number-input@1.41.2':
+    dependencies:
+      '@internationalized/number': 3.6.6
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dom-query': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
+  '@zag-js/pin-input@1.41.2':
+    dependencies:
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dom-query': 1.41.2
       '@zag-js/types': 1.41.2
       '@zag-js/utils': 1.41.2
 
@@ -2883,6 +2971,14 @@ snapshots:
     dependencies:
       '@zag-js/dom-query': 1.41.2
 
+  '@zag-js/slider@1.41.2':
+    dependencies:
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dom-query': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
   '@zag-js/store@1.41.2':
     dependencies:
       proxy-compare: 3.0.1
@@ -2904,11 +3000,30 @@ snapshots:
       '@zag-js/types': 1.41.2
       '@zag-js/utils': 1.41.2
 
+  '@zag-js/tags-input@1.41.2':
+    dependencies:
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/auto-resize': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dom-query': 1.41.2
+      '@zag-js/interact-outside': 1.41.2
+      '@zag-js/live-region': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
   '@zag-js/toast@1.41.2':
     dependencies:
       '@zag-js/anatomy': 1.41.2
       '@zag-js/core': 1.41.2
       '@zag-js/dismissable': 1.41.2
+      '@zag-js/dom-query': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
+  '@zag-js/toggle-group@1.41.2':
+    dependencies:
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/core': 1.41.2
       '@zag-js/dom-query': 1.41.2
       '@zag-js/types': 1.41.2
       '@zag-js/utils': 1.41.2


### PR DESCRIPTION
Add NumberInput, PinInput, Slider, TagsInput, Editable, and ToggleGroup adapters — thin renderers over the @manti-ui/folds Zag machines, with token-backed CSS keyed to data-scope/data-part/data-state and colocated stories. Completes Batch 3 of the zag-coverage tracker.