### PR TITLE
feat(react): adapt Zag.js Batch 4 selection & data

### DIFF
--- a/docs/zag-coverage.md
+++ b/docs/zag-coverage.md
@@ -56,15 +56,15 @@ Legend: ✅ done · ⬜ todo
 | Editable     | `@zag-js/editable`     |   ✅   |
 | Toggle Group | `@zag-js/toggle-group` |   ✅   |
 
-### Batch 4 — selection & data ⬜
+### Batch 4 — selection & data ✅
 
 | Component  | Package              | Status |
 | ---------- | -------------------- | :----: |
-| Select     | `@zag-js/select`     |   ⬜   |
-| Combobox   | `@zag-js/combobox`   |   ⬜   |
-| Listbox    | `@zag-js/listbox`    |   ⬜   |
-| Tree View  | `@zag-js/tree-view`  |   ⬜   |
-| Pagination | `@zag-js/pagination` |   ⬜   |
+| Select     | `@zag-js/select`     |   ✅   |
+| Combobox   | `@zag-js/combobox`   |   ✅   |
+| Listbox    | `@zag-js/listbox`    |   ✅   |
+| Tree View  | `@zag-js/tree-view`  |   ✅   |
+| Pagination | `@zag-js/pagination` |   ✅   |
 
 ### Batch 5 — display & media ⬜
 

--- a/packages/folds/package.json
+++ b/packages/folds/package.json
@@ -25,14 +25,18 @@
     "@zag-js/accordion": "^1.41.2",
     "@zag-js/checkbox": "^1.41.2",
     "@zag-js/collapsible": "^1.41.2",
+    "@zag-js/combobox": "^1.41.2",
     "@zag-js/dialog": "^1.41.2",
     "@zag-js/editable": "^1.41.2",
     "@zag-js/hover-card": "^1.41.2",
+    "@zag-js/listbox": "^1.41.2",
     "@zag-js/menu": "^1.41.2",
     "@zag-js/number-input": "^1.41.2",
+    "@zag-js/pagination": "^1.41.2",
     "@zag-js/pin-input": "^1.41.2",
     "@zag-js/popover": "^1.41.2",
     "@zag-js/radio-group": "^1.41.2",
+    "@zag-js/select": "^1.41.2",
     "@zag-js/slider": "^1.41.2",
     "@zag-js/switch": "^1.41.2",
     "@zag-js/tabs": "^1.41.2",
@@ -40,6 +44,7 @@
     "@zag-js/toast": "^1.41.2",
     "@zag-js/toggle": "^1.41.2",
     "@zag-js/toggle-group": "^1.41.2",
-    "@zag-js/tooltip": "^1.41.2"
+    "@zag-js/tooltip": "^1.41.2",
+    "@zag-js/tree-view": "^1.41.2"
   }
 }

--- a/packages/folds/src/index.ts
+++ b/packages/folds/src/index.ts
@@ -17,6 +17,11 @@ export * as slider from '@zag-js/slider';
 export * as tagsInput from '@zag-js/tags-input';
 export * as editable from '@zag-js/editable';
 export * as toggleGroup from '@zag-js/toggle-group';
+export * as select from '@zag-js/select';
+export * as combobox from '@zag-js/combobox';
+export * as listbox from '@zag-js/listbox';
+export * as treeView from '@zag-js/tree-view';
+export * as pagination from '@zag-js/pagination';
 
 export const mantiBehaviorContract = {
   packageName: '@manti-ui/folds',

--- a/packages/react/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/Combobox/Combobox.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Combobox } from './Combobox';
+
+const spices = [
+  { value: 'sumac', label: 'Sumac' },
+  { value: 'paprika', label: 'Paprika' },
+  { value: 'cumin', label: 'Cumin' },
+  { value: 'mint', label: 'Dried mint' },
+  { value: 'pepper', label: 'Black pepper' },
+  { value: 'chili', label: 'Chili flakes' },
+  { value: 'coriander', label: 'Coriander' },
+];
+
+const meta = {
+  title: 'Components/Combobox',
+  component: Combobox,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    items: spices,
+    label: 'Spice',
+    placeholder: 'Search spices…',
+    tone: 'primary',
+    size: 'md',
+    multiple: false,
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof Combobox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Multiple: Story = {
+  args: { multiple: true, label: 'Spices', defaultValue: ['sumac', 'mint'] },
+};

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -1,0 +1,151 @@
+import { useId, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { combobox } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, Portal, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+import type { Placement } from '../../internal/floating';
+
+export interface ComboboxItem {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface ComboboxProps {
+  /** The full option set; filtered client-side as the user types. */
+  items: ComboboxItem[];
+  /** Optional field label. */
+  label?: ReactNode;
+  placeholder?: string;
+  /** Selected-item tone. */
+  tone?: MantiTone;
+  /** Control size. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Allow selecting more than one option. */
+  multiple?: boolean;
+  /** Controlled selected values. */
+  value?: string[];
+  /** Initial selected values for uncontrolled usage. */
+  defaultValue?: string[];
+  /** Called whenever the selection changes. */
+  onValueChange?: (value: string[]) => void;
+  /** Placement of the listbox relative to the control. */
+  placement?: Placement;
+  disabled?: boolean;
+  invalid?: boolean;
+  required?: boolean;
+  /** Form field name. */
+  name?: string;
+  id?: string;
+  className?: string;
+}
+
+const check = (
+  <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M3.5 8.5l3 3 6-7"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/** A typeahead select backed by the Zag.js combobox machine. Filtering is
+ * client-side over the `items` prop; the listbox is portalled. */
+export function Combobox({
+  items,
+  label,
+  placeholder = 'Search…',
+  tone = 'primary',
+  size = 'md',
+  multiple,
+  value,
+  defaultValue,
+  onValueChange,
+  placement = 'bottom-start',
+  disabled,
+  invalid,
+  required,
+  name,
+  id,
+  className,
+}: ComboboxProps) {
+  const autoId = useId();
+  const [query, setQuery] = useState('');
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return q
+      ? items.filter((item) => item.label.toLowerCase().includes(q))
+      : items;
+  }, [items, query]);
+  const collection = useMemo(
+    () =>
+      combobox.collection({
+        items: filtered,
+        itemToString: (item) => item.label,
+        itemToValue: (item) => item.value,
+        isItemDisabled: (item) => Boolean(item.disabled),
+      }),
+    [filtered],
+  );
+  const service = useMachine(combobox.machine, {
+    id: id ?? autoId,
+    collection,
+    multiple,
+    value,
+    defaultValue,
+    disabled,
+    invalid,
+    required,
+    name,
+    positioning: { placement, sameWidth: true },
+    onInputValueChange: (details) => setQuery(details.inputValue),
+    onValueChange: onValueChange
+      ? (details) => onValueChange(details.value)
+      : undefined,
+  });
+  const api = combobox.connect(service, normalizeProps);
+
+  return (
+    <div
+      {...api.getRootProps()}
+      data-size={size}
+      data-tone={tone}
+      className={cx(className)}
+    >
+      {label != null && <label {...api.getLabelProps()}>{label}</label>}
+      <div {...api.getControlProps()}>
+        <input {...api.getInputProps()} placeholder={placeholder} />
+        <button {...api.getTriggerProps()} aria-label="Toggle options">
+          <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+            <path
+              d="M4 6l4 4 4-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+      <Portal>
+        <div {...api.getPositionerProps()}>
+          <ul {...api.getContentProps()}>
+            {filtered.map((item) => (
+              <li key={item.value} {...api.getItemProps({ item })}>
+                <span {...api.getItemTextProps({ item })}>{item.label}</span>
+                <span {...api.getItemIndicatorProps({ item })}>{check}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Portal>
+    </div>
+  );
+}

--- a/packages/react/src/components/Listbox/Listbox.stories.tsx
+++ b/packages/react/src/components/Listbox/Listbox.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Listbox } from './Listbox';
+
+const fillings = [
+  { value: 'lamb', label: 'Lamb & onion' },
+  { value: 'beef', label: 'Beef & herb' },
+  { value: 'pumpkin', label: 'Pumpkin' },
+  { value: 'potato', label: 'Potato', disabled: true },
+  { value: 'spinach', label: 'Spinach & cheese' },
+];
+
+const meta = {
+  title: 'Components/Listbox',
+  component: Listbox,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    items: fillings,
+    label: 'Filling',
+    tone: 'primary',
+    selectionMode: 'single',
+    defaultValue: ['beef'],
+  },
+  argTypes: {
+    selectionMode: { control: 'inline-radio', options: ['single', 'multiple'] },
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof Listbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Multiple: Story = {
+  args: { selectionMode: 'multiple', defaultValue: ['lamb', 'pumpkin'] },
+};

--- a/packages/react/src/components/Listbox/Listbox.tsx
+++ b/packages/react/src/components/Listbox/Listbox.tsx
@@ -1,0 +1,98 @@
+import { useId, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { listbox } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+
+export interface ListboxItem {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface ListboxProps {
+  /** The options. */
+  items: ListboxItem[];
+  /** Optional label above the list. */
+  label?: ReactNode;
+  /** Selected-item tone. */
+  tone?: MantiTone;
+  /** Single or multiple selection. */
+  selectionMode?: 'single' | 'multiple';
+  /** Controlled selected values. */
+  value?: string[];
+  /** Initial selected values for uncontrolled usage. */
+  defaultValue?: string[];
+  /** Called whenever the selection changes. */
+  onValueChange?: (value: string[]) => void;
+  disabled?: boolean;
+  id?: string;
+  className?: string;
+}
+
+const check = (
+  <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M3.5 8.5l3 3 6-7"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/** A selectable list backed by the Zag.js listbox machine. */
+export function Listbox({
+  items,
+  label,
+  tone = 'primary',
+  selectionMode = 'single',
+  value,
+  defaultValue,
+  onValueChange,
+  disabled,
+  id,
+  className,
+}: ListboxProps) {
+  const autoId = useId();
+  const collection = useMemo(
+    () =>
+      listbox.collection({
+        items,
+        itemToString: (item) => item.label,
+        itemToValue: (item) => item.value,
+        isItemDisabled: (item) => Boolean(item.disabled),
+      }),
+    [items],
+  );
+  const service = useMachine(listbox.machine, {
+    id: id ?? autoId,
+    collection,
+    selectionMode,
+    value,
+    defaultValue,
+    disabled,
+    onValueChange: onValueChange
+      ? (details) => onValueChange(details.value)
+      : undefined,
+  });
+  const api = listbox.connect(service, normalizeProps);
+
+  return (
+    <div {...api.getRootProps()} data-tone={tone} className={cx(className)}>
+      {label != null && <label {...api.getLabelProps()}>{label}</label>}
+      <ul {...api.getContentProps()}>
+        {items.map((item) => (
+          <li key={item.value} {...api.getItemProps({ item })}>
+            <span {...api.getItemTextProps({ item })}>{item.label}</span>
+            <span {...api.getItemIndicatorProps({ item })}>{check}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/react/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/Pagination/Pagination.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Pagination } from './Pagination';
+
+const meta = {
+  title: 'Components/Pagination',
+  component: Pagination,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    count: 200,
+    pageSize: 20,
+    defaultPage: 3,
+    siblingCount: 1,
+    size: 'md',
+    tone: 'primary',
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const FewPages: Story = {
+  args: { count: 60, pageSize: 20, defaultPage: 1 },
+};
+
+export const ManyPages: Story = {
+  args: { count: 1000, pageSize: 20, defaultPage: 12, siblingCount: 2 },
+};

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,98 @@
+import { useId } from 'react';
+import { pagination } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+
+export interface PaginationProps {
+  /** Total number of items across all pages. */
+  count: number;
+  /** Items per page. */
+  pageSize?: number;
+  /** Controlled current page (1-based). */
+  page?: number;
+  /** Initial page for uncontrolled usage. */
+  defaultPage?: number;
+  /** Called whenever the page changes. */
+  onPageChange?: (page: number) => void;
+  /** Pages shown on each side of the current page. */
+  siblingCount?: number;
+  /** Control size. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Active-page tone. */
+  tone?: MantiTone;
+  id?: string;
+  className?: string;
+}
+
+const arrow = (d: string) => (
+  <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d={d}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/** A page navigator backed by the Zag.js pagination machine. */
+export function Pagination({
+  count,
+  pageSize,
+  page,
+  defaultPage,
+  onPageChange,
+  siblingCount,
+  size = 'md',
+  tone = 'primary',
+  id,
+  className,
+}: PaginationProps) {
+  const autoId = useId();
+  const service = useMachine(pagination.machine, {
+    id: id ?? autoId,
+    count,
+    pageSize,
+    page,
+    defaultPage,
+    siblingCount,
+    onPageChange: onPageChange
+      ? (details) => onPageChange(details.page)
+      : undefined,
+  });
+  const api = pagination.connect(service, normalizeProps);
+
+  return (
+    <nav
+      {...api.getRootProps()}
+      data-size={size}
+      data-tone={tone}
+      className={cx(className)}
+    >
+      <button {...api.getPrevTriggerProps()} aria-label="Previous page">
+        {arrow('M10 3 5 8l5 5')}
+      </button>
+      {api.pages.map((page, index) =>
+        page.type === 'page' ? (
+          <button
+            key={page.value}
+            {...api.getItemProps({ type: 'page', value: page.value })}
+          >
+            {page.value}
+          </button>
+        ) : (
+          <span key={`ellipsis-${index}`} {...api.getEllipsisProps({ index })}>
+            &#8230;
+          </span>
+        ),
+      )}
+      <button {...api.getNextTriggerProps()} aria-label="Next page">
+        {arrow('M6 3l5 5-5 5')}
+      </button>
+    </nav>
+  );
+}

--- a/packages/react/src/components/Select/Select.stories.tsx
+++ b/packages/react/src/components/Select/Select.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Select } from './Select';
+
+const regions = [
+  { value: 'kayseri', label: 'Kayseri' },
+  { value: 'bukhara', label: 'Bukhara' },
+  { value: 'kashgar', label: 'Kashgar' },
+  { value: 'yerevan', label: 'Yerevan' },
+  { value: 'sarajevo', label: 'Sarajevo' },
+];
+
+const meta = {
+  title: 'Components/Select',
+  component: Select,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    items: regions,
+    label: 'Region',
+    placeholder: 'Pick a region…',
+    tone: 'primary',
+    size: 'md',
+    multiple: false,
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof Select>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Multiple: Story = {
+  args: {
+    multiple: true,
+    label: 'Regions',
+    defaultValue: ['kayseri', 'kashgar'],
+  },
+};
+
+export const States: Story = {
+  render: (args) => (
+    <div style={{ display: 'grid', gap: '1rem', width: 260 }}>
+      <Select {...args} label="Default" />
+      <Select {...args} label="Invalid" invalid />
+      <Select {...args} label="Disabled" disabled />
+    </div>
+  ),
+};

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -1,0 +1,159 @@
+import { useId, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { select } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, Portal, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+import type { Placement } from '../../internal/floating';
+
+export interface SelectItem {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface SelectProps {
+  /** The options. */
+  items: SelectItem[];
+  /** Optional field label. */
+  label?: ReactNode;
+  /** Text shown when nothing is selected. */
+  placeholder?: string;
+  /** Selected-item tone. */
+  tone?: MantiTone;
+  /** Control size. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Allow selecting more than one option. */
+  multiple?: boolean;
+  /** Controlled selected values. */
+  value?: string[];
+  /** Initial selected values for uncontrolled usage. */
+  defaultValue?: string[];
+  /** Called whenever the selection changes. */
+  onValueChange?: (value: string[]) => void;
+  /** Placement of the listbox relative to the trigger. */
+  placement?: Placement;
+  disabled?: boolean;
+  invalid?: boolean;
+  required?: boolean;
+  /** Form field name. */
+  name?: string;
+  id?: string;
+  className?: string;
+}
+
+const check = (
+  <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M3.5 8.5l3 3 6-7"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/** A single/multi select backed by the Zag.js select machine. The machine owns
+ * keyboard, typeahead, and dismissal; this adapter renders the trigger and the
+ * portalled frosted listbox. */
+export function Select({
+  items,
+  label,
+  placeholder = 'Select…',
+  tone = 'primary',
+  size = 'md',
+  multiple,
+  value,
+  defaultValue,
+  onValueChange,
+  placement = 'bottom-start',
+  disabled,
+  invalid,
+  required,
+  name,
+  id,
+  className,
+}: SelectProps) {
+  const autoId = useId();
+  const collection = useMemo(
+    () =>
+      select.collection({
+        items,
+        itemToString: (item) => item.label,
+        itemToValue: (item) => item.value,
+        isItemDisabled: (item) => Boolean(item.disabled),
+      }),
+    [items],
+  );
+  const service = useMachine(select.machine, {
+    id: id ?? autoId,
+    collection,
+    multiple,
+    value,
+    defaultValue,
+    disabled,
+    invalid,
+    required,
+    name,
+    positioning: { placement, sameWidth: true },
+    onValueChange: onValueChange
+      ? (details) => onValueChange(details.value)
+      : undefined,
+  });
+  const api = select.connect(service, normalizeProps);
+
+  return (
+    <div
+      {...api.getRootProps()}
+      data-size={size}
+      data-tone={tone}
+      className={cx(className)}
+    >
+      {label != null && <label {...api.getLabelProps()}>{label}</label>}
+      <div {...api.getControlProps()}>
+        <button {...api.getTriggerProps()}>
+          <span
+            {...api.getValueTextProps()}
+            data-placeholder={api.empty || undefined}
+          >
+            {api.empty ? placeholder : api.valueAsString}
+          </span>
+          <span {...api.getIndicatorProps()}>
+            <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                d="M4 6l4 4 4-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <Portal>
+        <div {...api.getPositionerProps()}>
+          <ul {...api.getContentProps()}>
+            {items.map((item) => (
+              <li key={item.value} {...api.getItemProps({ item })}>
+                <span {...api.getItemTextProps({ item })}>{item.label}</span>
+                <span {...api.getItemIndicatorProps({ item })}>{check}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Portal>
+      <select {...api.getHiddenSelectProps()}>
+        {items.map((item) => (
+          <option key={item.value} value={item.value}>
+            {item.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/packages/react/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react/src/components/TreeView/TreeView.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TreeView } from './TreeView';
+
+const tree = [
+  {
+    value: 'recipes',
+    label: 'recipes',
+    children: [
+      {
+        value: 'steamed',
+        label: 'steamed',
+        children: [
+          { value: 'manti', label: 'manti.md' },
+          { value: 'momo', label: 'momo.md' },
+        ],
+      },
+      {
+        value: 'boiled',
+        label: 'boiled',
+        children: [{ value: 'pelmeni', label: 'pelmeni.md' }],
+      },
+    ],
+  },
+  {
+    value: 'sauces',
+    label: 'sauces',
+    children: [
+      { value: 'yogurt', label: 'garlic-yogurt.md' },
+      { value: 'chili-oil', label: 'chili-oil.md' },
+    ],
+  },
+  { value: 'README', label: 'README.md' },
+];
+
+const meta = {
+  title: 'Components/TreeView',
+  component: TreeView,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  args: {
+    items: tree,
+    label: 'Cookbook',
+    tone: 'primary',
+    selectionMode: 'single',
+    defaultExpandedValue: ['recipes', 'steamed'],
+  },
+  argTypes: {
+    selectionMode: { control: 'inline-radio', options: ['single', 'multiple'] },
+    tone: {
+      control: 'select',
+      options: ['primary', 'neutral', 'success', 'warning', 'danger', 'info'],
+    },
+  },
+} satisfies Meta<typeof TreeView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const MultiSelect: Story = {
+  args: { selectionMode: 'multiple', defaultSelectedValue: ['manti', 'momo'] },
+};

--- a/packages/react/src/components/TreeView/TreeView.tsx
+++ b/packages/react/src/components/TreeView/TreeView.tsx
@@ -1,0 +1,115 @@
+import { useId, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { treeView } from '@manti-ui/folds';
+import type { MantiTone } from '@manti-ui/tokens';
+import { normalizeProps, useMachine } from '@zag-js/react';
+
+import { cx } from '../../internal/props';
+
+export interface TreeNode {
+  value: string;
+  label: string;
+  children?: TreeNode[];
+}
+
+export interface TreeViewProps {
+  /** Top-level nodes. Branches carry a `children` array. */
+  items: TreeNode[];
+  /** Optional label above the tree. */
+  label?: ReactNode;
+  /** Selected-node tone. */
+  tone?: MantiTone;
+  /** Single or multiple selection. */
+  selectionMode?: 'single' | 'multiple';
+  /** Values of branches expanded by default. */
+  defaultExpandedValue?: string[];
+  /** Values selected by default. */
+  defaultSelectedValue?: string[];
+  /** Called whenever the selection changes. */
+  onSelectionChange?: (value: string[]) => void;
+  id?: string;
+  className?: string;
+}
+
+const chevron = (
+  <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+    <path
+      d="M5 3l4 4-4 4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/** A nested, keyboard-navigable tree backed by the Zag.js tree-view machine. */
+export function TreeView({
+  items,
+  label,
+  tone = 'primary',
+  selectionMode = 'single',
+  defaultExpandedValue,
+  defaultSelectedValue,
+  onSelectionChange,
+  id,
+  className,
+}: TreeViewProps) {
+  const autoId = useId();
+  const collection = useMemo(
+    () =>
+      treeView.collection<TreeNode>({
+        rootNode: { value: 'ROOT', label: '', children: items },
+        nodeToValue: (node) => node.value,
+        nodeToString: (node) => node.label,
+        nodeToChildren: (node) => node.children ?? [],
+      }),
+    [items],
+  );
+  const service = useMachine(treeView.machine, {
+    id: id ?? autoId,
+    collection,
+    selectionMode,
+    defaultExpandedValue,
+    defaultSelectedValue,
+    onSelectionChange: onSelectionChange
+      ? (details) => onSelectionChange(details.selectedValue)
+      : undefined,
+  });
+  const api = treeView.connect(service, normalizeProps);
+
+  const renderNode = (node: TreeNode, indexPath: number[]): ReactNode => {
+    const nodeProps = { node, indexPath };
+    const children = node.children;
+    if (children != null && children.length > 0) {
+      return (
+        <div key={node.value} {...api.getBranchProps(nodeProps)}>
+          <div {...api.getBranchControlProps(nodeProps)}>
+            <span {...api.getBranchIndicatorProps(nodeProps)}>{chevron}</span>
+            <span {...api.getBranchTextProps(nodeProps)}>{node.label}</span>
+          </div>
+          <div {...api.getBranchContentProps(nodeProps)}>
+            {children.map((child, index) =>
+              renderNode(child, [...indexPath, index]),
+            )}
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div key={node.value} {...api.getItemProps(nodeProps)}>
+        <span {...api.getItemTextProps(nodeProps)}>{node.label}</span>
+      </div>
+    );
+  };
+
+  return (
+    <div {...api.getRootProps()} data-tone={tone} className={cx(className)}>
+      {label != null && <h3 {...api.getLabelProps()}>{label}</h3>}
+      <div {...api.getTreeProps()}>
+        {items.map((node, index) => renderNode(node, [index]))}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -19,6 +19,9 @@ export type { CheckboxProps } from './Checkbox/Checkbox';
 export { Collapsible } from './Collapsible/Collapsible';
 export type { CollapsibleProps } from './Collapsible/Collapsible';
 
+export { Combobox } from './Combobox/Combobox';
+export type { ComboboxItem, ComboboxProps } from './Combobox/Combobox';
+
 export { Dialog } from './Dialog/Dialog';
 export type { DialogProps, DialogSize } from './Dialog/Dialog';
 
@@ -27,6 +30,9 @@ export type { EditableProps } from './Editable/Editable';
 
 export { HoverCard } from './HoverCard/HoverCard';
 export type { HoverCardProps } from './HoverCard/HoverCard';
+
+export { Listbox } from './Listbox/Listbox';
+export type { ListboxItem, ListboxProps } from './Listbox/Listbox';
 
 export { Menu } from './Menu/Menu';
 export type {
@@ -40,6 +46,9 @@ export type {
 export { NumberInput } from './NumberInput/NumberInput';
 export type { NumberInputProps } from './NumberInput/NumberInput';
 
+export { Pagination } from './Pagination/Pagination';
+export type { PaginationProps } from './Pagination/Pagination';
+
 export { PinInput } from './PinInput/PinInput';
 export type { PinInputProps } from './PinInput/PinInput';
 
@@ -48,6 +57,9 @@ export type { PopoverProps } from './Popover/Popover';
 
 export { RadioGroup } from './RadioGroup/RadioGroup';
 export type { RadioGroupItem, RadioGroupProps } from './RadioGroup/RadioGroup';
+
+export { Select } from './Select/Select';
+export type { SelectItem, SelectProps } from './Select/Select';
 
 export { Slider } from './Slider/Slider';
 export type { SliderProps } from './Slider/Slider';
@@ -63,6 +75,9 @@ export type { TabItem, TabsProps } from './Tabs/Tabs';
 
 export { TagsInput } from './TagsInput/TagsInput';
 export type { TagsInputProps } from './TagsInput/TagsInput';
+
+export { TreeView } from './TreeView/TreeView';
+export type { TreeNode, TreeViewProps } from './TreeView/TreeView';
 
 export { createToaster } from './Toast/Toast';
 export type {

--- a/packages/styles/src/components/combobox.css
+++ b/packages/styles/src/components/combobox.css
@@ -1,0 +1,178 @@
+/**
+ * Combobox — a typeahead select backed by the Zag.js combobox machine. The
+ * control is the frosted field with an inline toggle; the portalled content
+ * matches the Select/Listbox panels.
+ */
+@layer manti.components {
+  [data-scope='combobox'][data-part='root'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-2);
+    min-width: 0;
+  }
+
+  [data-scope='combobox'][data-part='label'] {
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    color: var(--manti-text);
+  }
+
+  [data-scope='combobox'][data-part='control'] {
+    --_min-height: 2.5rem;
+
+    display: flex;
+    align-items: center;
+    min-height: var(--_min-height);
+    padding-inline: var(--manti-space-3);
+    background: var(--manti-glass-tint-strong);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    box-shadow:
+      inset 0 1px 0 0 var(--manti-glass-highlight),
+      inset 0 2px 5px -3px var(--manti-glass-shadow-color);
+    transition:
+      border-color var(--manti-duration-base) var(--manti-ease-smooth),
+      box-shadow var(--manti-duration-base) var(--manti-ease-smooth);
+
+    &:hover {
+      border-color: var(--manti-text-subtle);
+    }
+
+    &:focus-within {
+      border-color: var(--tone-ring, var(--manti-focus-ring));
+      box-shadow:
+        inset 0 1px 0 0 var(--manti-glass-highlight),
+        0 0 0 3px
+          color-mix(
+            in oklab,
+            var(--tone-ring, var(--manti-focus-ring)) 30%,
+            transparent
+          );
+    }
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='combobox'][data-part='control'] {
+      background: var(--manti-surface-raised);
+    }
+  }
+
+  [data-scope='combobox'][data-part='root'][data-size='sm']
+    [data-part='control'] {
+    --_min-height: 2rem;
+  }
+
+  [data-scope='combobox'][data-part='root'][data-size='lg']
+    [data-part='control'] {
+    --_min-height: 3rem;
+  }
+
+  [data-scope='combobox'][data-part='root'][data-invalid]
+    [data-part='control'] {
+    border-color: light-dark(var(--manti-chili-500), var(--manti-chili-400));
+  }
+
+  [data-scope='combobox'][data-part='input'] {
+    flex: 1;
+    min-width: 0;
+    background: none;
+    border: none;
+    outline: none;
+    color: var(--manti-text);
+    font-size: var(--manti-text-sm);
+
+    &::placeholder {
+      color: var(--manti-text-subtle);
+    }
+  }
+
+  [data-scope='combobox'][data-part='trigger'] {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    margin-inline-start: var(--manti-space-2);
+    color: var(--manti-text-muted);
+    cursor: pointer;
+    transition: color var(--manti-duration-fast) var(--manti-ease-smooth);
+
+    &:hover {
+      color: var(--manti-text);
+    }
+  }
+
+  [data-scope='combobox'][data-part='positioner'] {
+    z-index: var(--manti-z-popover, 1100);
+  }
+
+  [data-scope='combobox'][data-part='content'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-1);
+    max-height: 18rem;
+    overflow-y: auto;
+    padding: var(--manti-space-2);
+    background: var(--manti-glass-tint-strong);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    box-shadow:
+      inset 0 1px 0 0 var(--manti-glass-highlight),
+      var(--manti-glass-shadow);
+
+    &:focus-visible {
+      outline: none;
+    }
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='combobox'][data-part='content'] {
+      background: var(--manti-surface-raised);
+    }
+  }
+
+  [data-scope='combobox'][data-part='item'] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--manti-space-2);
+    padding: var(--manti-space-2) var(--manti-space-3);
+    border-radius: var(--manti-radius-sm);
+    color: var(--manti-text);
+    font-size: var(--manti-text-sm);
+    cursor: pointer;
+    user-select: none;
+    transition: background var(--manti-duration-fast) var(--manti-ease-soft);
+
+    &[data-highlighted] {
+      background: color-mix(in oklab, var(--manti-text) 8%, transparent);
+    }
+
+    &[data-state='checked'] {
+      color: var(--tone-text);
+      font-weight: var(--manti-weight-medium);
+    }
+
+    &[data-disabled] {
+      color: var(--manti-text-subtle);
+      cursor: not-allowed;
+    }
+  }
+
+  [data-scope='combobox'][data-part='item-indicator'] {
+    display: inline-flex;
+    flex: none;
+    color: var(--tone-text);
+  }
+}

--- a/packages/styles/src/components/listbox.css
+++ b/packages/styles/src/components/listbox.css
@@ -1,0 +1,80 @@
+/**
+ * Listbox — a selectable list backed by the Zag.js listbox machine. The list is
+ * a frosted panel; the highlighted row (`data-highlighted`) lifts and the
+ * selected row (`data-state='checked'`) shows the active-tone check.
+ */
+@layer manti.components {
+  [data-scope='listbox'][data-part='root'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-2);
+  }
+
+  [data-scope='listbox'][data-part='label'] {
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    color: var(--manti-text);
+  }
+
+  [data-scope='listbox'][data-part='content'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-1);
+    min-width: 14rem;
+    max-height: 18rem;
+    overflow-y: auto;
+    padding: var(--manti-space-2);
+    background: var(--manti-glass-tint-strong);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    box-shadow: inset 0 1px 0 0 var(--manti-glass-highlight);
+
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='listbox'][data-part='content'] {
+      background: var(--manti-surface-raised);
+    }
+  }
+
+  [data-scope='listbox'][data-part='item'] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--manti-space-2);
+    padding: var(--manti-space-2) var(--manti-space-3);
+    border-radius: var(--manti-radius-sm);
+    color: var(--manti-text);
+    font-size: var(--manti-text-sm);
+    cursor: pointer;
+    user-select: none;
+    transition: background var(--manti-duration-fast) var(--manti-ease-soft);
+
+    &[data-highlighted] {
+      background: color-mix(in oklab, var(--manti-text) 8%, transparent);
+    }
+
+    &[data-state='checked'] {
+      color: var(--tone-text);
+      font-weight: var(--manti-weight-medium);
+    }
+
+    &[data-disabled] {
+      color: var(--manti-text-subtle);
+      cursor: not-allowed;
+    }
+  }
+
+  [data-scope='listbox'][data-part='item-indicator'] {
+    display: inline-flex;
+    flex: none;
+    color: var(--tone-text);
+  }
+}

--- a/packages/styles/src/components/pagination.css
+++ b/packages/styles/src/components/pagination.css
@@ -1,0 +1,96 @@
+/**
+ * Pagination — a page navigator backed by the Zag.js pagination machine. Items
+ * are quiet ghost buttons; the current page (`data-selected`) fills with the
+ * active tone.
+ */
+@layer manti.components {
+  [data-scope='pagination'][data-part='root'] {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--manti-space-1);
+  }
+
+  [data-scope='pagination'][data-part='item'],
+  [data-scope='pagination'][data-part='prev-trigger'],
+  [data-scope='pagination'][data-part='next-trigger'],
+  [data-scope='pagination'][data-part='ellipsis'] {
+    --_size: 2.25rem;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--_size);
+    height: var(--_size);
+    padding-inline: var(--manti-space-2);
+    border: 1px solid transparent;
+    border-radius: var(--manti-radius-sm);
+    color: var(--manti-text-muted);
+    font-family: var(--manti-font-sans);
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    font-variant-numeric: tabular-nums;
+  }
+
+  [data-scope='pagination'][data-part='root'][data-size='sm']
+    :is(
+      [data-part='item'],
+      [data-part='prev-trigger'],
+      [data-part='next-trigger'],
+      [data-part='ellipsis']
+    ) {
+    --_size: 1.875rem;
+    font-size: var(--manti-text-xs);
+  }
+
+  [data-scope='pagination'][data-part='root'][data-size='lg']
+    :is(
+      [data-part='item'],
+      [data-part='prev-trigger'],
+      [data-part='next-trigger'],
+      [data-part='ellipsis']
+    ) {
+    --_size: 2.75rem;
+    font-size: var(--manti-text-base);
+  }
+
+  [data-scope='pagination'][data-part='item'],
+  [data-scope='pagination'][data-part='prev-trigger'],
+  [data-scope='pagination'][data-part='next-trigger'] {
+    cursor: pointer;
+    transition:
+      background-color var(--manti-duration-fast) var(--manti-ease-smooth),
+      color var(--manti-duration-fast) var(--manti-ease-smooth),
+      border-color var(--manti-duration-fast) var(--manti-ease-smooth);
+
+    &:hover {
+      background: color-mix(in oklab, var(--tone-soft-bg) 60%, transparent);
+      color: var(--tone-soft-text);
+    }
+
+    &:focus-visible {
+      outline: var(--manti-focus-ring-width) solid var(--tone-ring);
+      outline-offset: var(--manti-focus-ring-offset);
+    }
+
+    &:disabled {
+      color: var(--manti-text-subtle);
+      cursor: not-allowed;
+      background: none;
+    }
+  }
+
+  [data-scope='pagination'][data-part='item'][data-selected] {
+    background: var(--tone-solid);
+    color: var(--tone-on-solid);
+    box-shadow: var(--manti-shadow-sm);
+
+    &:hover {
+      background: var(--tone-solid-hover);
+      color: var(--tone-on-solid);
+    }
+  }
+
+  [data-scope='pagination'][data-part='ellipsis'] {
+    color: var(--manti-text-subtle);
+  }
+}

--- a/packages/styles/src/components/select.css
+++ b/packages/styles/src/components/select.css
@@ -1,0 +1,176 @@
+/**
+ * Select — single/multi select backed by the Zag.js select machine. The trigger
+ * reuses the frosted field surface; the portalled content is a frosted listbox
+ * matching the Listbox/Menu panels.
+ */
+@layer manti.components {
+  [data-scope='select'][data-part='root'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-2);
+    min-width: 0;
+  }
+
+  [data-scope='select'][data-part='label'] {
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-medium);
+    color: var(--manti-text);
+  }
+
+  [data-scope='select'][data-part='trigger'] {
+    --_min-height: 2.5rem;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--manti-space-2);
+    width: 100%;
+    min-height: var(--_min-height);
+    padding-inline: var(--manti-space-3);
+    background: var(--manti-glass-tint-strong);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    color: var(--manti-text);
+    font-family: var(--manti-font-sans);
+    font-size: var(--manti-text-sm);
+    text-align: start;
+    cursor: pointer;
+    box-shadow:
+      inset 0 1px 0 0 var(--manti-glass-highlight),
+      inset 0 2px 5px -3px var(--manti-glass-shadow-color);
+    transition:
+      border-color var(--manti-duration-base) var(--manti-ease-smooth),
+      box-shadow var(--manti-duration-base) var(--manti-ease-smooth);
+
+    &:hover {
+      border-color: var(--manti-text-subtle);
+    }
+
+    &[data-state='open'],
+    &:focus-visible {
+      outline: none;
+      border-color: var(--tone-ring, var(--manti-focus-ring));
+      box-shadow:
+        inset 0 1px 0 0 var(--manti-glass-highlight),
+        0 0 0 3px
+          color-mix(
+            in oklab,
+            var(--tone-ring, var(--manti-focus-ring)) 30%,
+            transparent
+          );
+    }
+
+    &[data-disabled] {
+      background: var(--manti-surface-sunken);
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='select'][data-part='trigger'] {
+      background: var(--manti-surface-raised);
+    }
+  }
+
+  [data-scope='select'][data-part='root'][data-size='sm']
+    [data-part='trigger'] {
+    --_min-height: 2rem;
+  }
+
+  [data-scope='select'][data-part='root'][data-size='lg']
+    [data-part='trigger'] {
+    --_min-height: 3rem;
+  }
+
+  [data-scope='select'][data-part='root'][data-invalid] [data-part='trigger'] {
+    border-color: light-dark(var(--manti-chili-500), var(--manti-chili-400));
+  }
+
+  [data-scope='select'][data-part='value-text'][data-placeholder] {
+    color: var(--manti-text-subtle);
+  }
+
+  [data-scope='select'][data-part='indicator'] {
+    display: inline-flex;
+    flex: none;
+    color: var(--manti-text-muted);
+    transition: transform var(--manti-duration-base) var(--manti-ease-smooth);
+  }
+
+  [data-scope='select'][data-part='trigger'][data-state='open']
+    [data-part='indicator'] {
+    transform: rotate(180deg);
+  }
+
+  [data-scope='select'][data-part='positioner'] {
+    z-index: var(--manti-z-popover, 1100);
+  }
+
+  [data-scope='select'][data-part='content'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-1);
+    max-height: 18rem;
+    overflow-y: auto;
+    padding: var(--manti-space-2);
+    background: var(--manti-glass-tint-strong);
+    -webkit-backdrop-filter: var(--manti-glass-blur);
+    backdrop-filter: var(--manti-glass-blur);
+    border: 1px solid var(--manti-glass-border);
+    border-radius: var(--manti-radius-md);
+    box-shadow:
+      inset 0 1px 0 0 var(--manti-glass-highlight),
+      var(--manti-glass-shadow);
+
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='select'][data-part='content'] {
+      background: var(--manti-surface-raised);
+    }
+  }
+
+  [data-scope='select'][data-part='item'] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--manti-space-2);
+    padding: var(--manti-space-2) var(--manti-space-3);
+    border-radius: var(--manti-radius-sm);
+    color: var(--manti-text);
+    font-size: var(--manti-text-sm);
+    cursor: pointer;
+    user-select: none;
+    transition: background var(--manti-duration-fast) var(--manti-ease-soft);
+
+    &[data-highlighted] {
+      background: color-mix(in oklab, var(--manti-text) 8%, transparent);
+    }
+
+    &[data-state='checked'] {
+      color: var(--tone-text);
+      font-weight: var(--manti-weight-medium);
+    }
+
+    &[data-disabled] {
+      color: var(--manti-text-subtle);
+      cursor: not-allowed;
+    }
+  }
+
+  [data-scope='select'][data-part='item-indicator'] {
+    display: inline-flex;
+    flex: none;
+    color: var(--tone-text);
+  }
+}

--- a/packages/styles/src/components/tree-view.css
+++ b/packages/styles/src/components/tree-view.css
@@ -1,0 +1,92 @@
+/**
+ * Tree View — a nested, keyboard-navigable tree backed by the Zag.js tree-view
+ * machine. Rows are quiet until hovered/focused; the selected row
+ * (`data-selected`) takes the soft tone. Branch content indents one step per
+ * depth and the chevron rotates on expand (`data-state='open'`).
+ */
+@layer manti.components {
+  [data-scope='tree-view'][data-part='root'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-2);
+  }
+
+  [data-scope='tree-view'][data-part='label'] {
+    margin: 0;
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-semibold);
+    color: var(--manti-text);
+  }
+
+  [data-scope='tree-view'][data-part='tree'] {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  [data-scope='tree-view'][data-part='item'],
+  [data-scope='tree-view'][data-part='branch-control'] {
+    display: flex;
+    align-items: center;
+    gap: var(--manti-space-2);
+    padding: var(--manti-space-2) var(--manti-space-3);
+    border-radius: var(--manti-radius-sm);
+    color: var(--manti-text);
+    font-size: var(--manti-text-sm);
+    cursor: pointer;
+    user-select: none;
+    transition: background var(--manti-duration-fast) var(--manti-ease-soft);
+
+    &:hover {
+      background: color-mix(in oklab, var(--manti-text) 6%, transparent);
+    }
+
+    &[data-selected] {
+      background: color-mix(in oklab, var(--tone-soft-bg) 70%, transparent);
+      color: var(--tone-soft-text);
+    }
+
+    &[data-focus] {
+      outline: var(--manti-focus-ring-width) solid var(--tone-ring);
+      outline-offset: calc(var(--manti-focus-ring-offset) * -1);
+    }
+
+    &[data-disabled] {
+      color: var(--manti-text-subtle);
+      cursor: not-allowed;
+    }
+  }
+
+  [data-scope='tree-view'][data-part='branch-indicator'] {
+    display: inline-flex;
+    flex: none;
+    color: var(--manti-text-muted);
+    transition: transform var(--manti-duration-base) var(--manti-ease-smooth);
+
+    &[data-state='open'] {
+      transform: rotate(90deg);
+    }
+  }
+
+  [data-scope='tree-view'][data-part='branch-text'],
+  [data-scope='tree-view'][data-part='item-text'] {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Indent each nested level. Leaf items align with their branch text by adding
+     the indicator's width to the inset. */
+  [data-scope='tree-view'][data-part='branch-content'] {
+    padding-inline-start: var(--manti-space-4);
+  }
+
+  [data-scope='tree-view'][data-part='branch-content'] [data-part='item'] {
+    padding-inline-start: calc(var(--manti-space-3) + var(--manti-space-5));
+  }
+}

--- a/packages/styles/src/index.css
+++ b/packages/styles/src/index.css
@@ -35,6 +35,11 @@
 @import './components/tags-input.css';
 @import './components/editable.css';
 @import './components/toggle-group.css';
+@import './components/select.css';
+@import './components/combobox.css';
+@import './components/listbox.css';
+@import './components/tree-view.css';
+@import './components/pagination.css';
 
 /* Motion tiers — declared last so [data-motion] overrides win by layer order.
    Import `none` after `full` so an inner [data-motion="none"] subtree reliably

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@zag-js/collapsible':
         specifier: ^1.41.2
         version: 1.41.2
+      '@zag-js/combobox':
+        specifier: ^1.41.2
+        version: 1.41.2
       '@zag-js/dialog':
         specifier: ^1.41.2
         version: 1.41.2
@@ -77,10 +80,16 @@ importers:
       '@zag-js/hover-card':
         specifier: ^1.41.2
         version: 1.41.2
+      '@zag-js/listbox':
+        specifier: ^1.41.2
+        version: 1.41.2
       '@zag-js/menu':
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/number-input':
+        specifier: ^1.41.2
+        version: 1.41.2
+      '@zag-js/pagination':
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/pin-input':
@@ -90,6 +99,9 @@ importers:
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/radio-group':
+        specifier: ^1.41.2
+        version: 1.41.2
+      '@zag-js/select':
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/slider':
@@ -114,6 +126,9 @@ importers:
         specifier: ^1.41.2
         version: 1.41.2
       '@zag-js/tooltip':
+        specifier: ^1.41.2
+        version: 1.41.2
+      '@zag-js/tree-view':
         specifier: ^1.41.2
         version: 1.41.2
 
@@ -1106,6 +1121,12 @@ packages:
   '@zag-js/collapsible@1.41.2':
     resolution: {integrity: sha512-uMIp4rqd3iI6VFPMAOcbu9dh9WV4l85nNPYQiBtMKRHgbkfaZdfzF+E+NX3KquIeHW6JiBFUiIyCU0Sf2Cscdw==}
 
+  '@zag-js/collection@1.41.2':
+    resolution: {integrity: sha512-ZZWuvfPZI8ccWd4aLpuU47k1jSc9eO+F3FM3iBJuvgegCH6g3+HDEwGN6wdePHnYfv7zyIKCGKr816zXcIWQbw==}
+
+  '@zag-js/combobox@1.41.2':
+    resolution: {integrity: sha512-V9jQteyQHs8ZNQx/FcA98P1NVZas/yjiW1V7s4L+h8MnRS3AK97+FAHAT83KCiZ34/vkpLF6ZEHI2zkcQpNXcg==}
+
   '@zag-js/core@1.41.2':
     resolution: {integrity: sha512-xXTN3zKwOtMI4+5dG2cG+T1B4WR3X9alXiYaPJKaGd4N2eYRj9JEPte3Hv9gtFm+RM0b9VIwksHEg25rqE4apw==}
 
@@ -1133,6 +1154,9 @@ packages:
   '@zag-js/interact-outside@1.41.2':
     resolution: {integrity: sha512-dM4Fn9iyqQeqkCMRYZP+bAgWEPKRVQRqMmcPsN0OXBhhFKC31Em15LTIZXaOtVKAjH+iwx+UvSYFRiWwEjkOEA==}
 
+  '@zag-js/listbox@1.41.2':
+    resolution: {integrity: sha512-iDGrZleP3ui2Q6Jgmr9RYlbd7njdJHs8Qb3IJrSIZBIeYyYmFvVUfAFjk0g/z/amjTx6uYxRASWSPy/RETd4ug==}
+
   '@zag-js/live-region@1.41.2':
     resolution: {integrity: sha512-7ubIW5AQt1wx9S/gFN+rU4TyvuFWJrL/DhnDWPNlH5g3luDVHSNeYGeeqf4d4tkcibtpYZa0pg9CbXxRxrfwVA==}
 
@@ -1141,6 +1165,9 @@ packages:
 
   '@zag-js/number-input@1.41.2':
     resolution: {integrity: sha512-QoQWCiVHO+ciUbq8uL8Kxhtk4o3UpwzYpJkfsOfitzsZoYpPc7V/A6+n5yABV2SOwpqBODwNASZdxiEa60kfow==}
+
+  '@zag-js/pagination@1.41.2':
+    resolution: {integrity: sha512-vZTxz4DrIDfedMcTjDeEkOc1iXD9wkP8eKuEcDieHOodnjSnNNwtmoFw5DCWv+yEa/TByIamXBZ8ZxHY144JgA==}
 
   '@zag-js/pin-input@1.41.2':
     resolution: {integrity: sha512-Wrn3YDbmWL3qvUIzN4QyLO7PzEhunX7z8DwBpmrK04p7HxR9pniTLVIPk27xk2MzyAPYcl4mwd9/Mc88tBxHsg==}
@@ -1165,6 +1192,9 @@ packages:
 
   '@zag-js/remove-scroll@1.41.2':
     resolution: {integrity: sha512-ieIrOgPKlCikAGEBIboQJoU7oxrL5BEY670tDOu7Eg7rNOdAwGXLEKPX2A/q+lREhOiVYjx0D3//vHTvdte80Q==}
+
+  '@zag-js/select@1.41.2':
+    resolution: {integrity: sha512-3wGaKABILexoNBJ1bJiHqLLTctR/VMZaNA4cyKiqZeBEWtAkdMhgyY2xKobrP6KtUTqAeUFNVSTu4yCDrAQnUw==}
 
   '@zag-js/slider@1.41.2':
     resolution: {integrity: sha512-mKK2BwoDbIGxAdkdKkPZJA1SHtEQt3lS9hJ6WghefYU2vyd0BXoIKvcDV3xJOzly5LXYhH5cJITn6JtGK8353A==}
@@ -1192,6 +1222,9 @@ packages:
 
   '@zag-js/tooltip@1.41.2':
     resolution: {integrity: sha512-68okWJCFXfW8r0h97kEcU2yKPkq6e0S6QkiYh09ifMXoYjrQw/shPol8PgrS1poqKJigUWtsKm+bw73abhMn3w==}
+
+  '@zag-js/tree-view@1.41.2':
+    resolution: {integrity: sha512-QNi0VpV+RyzF4NP72+kSleUpauF9SMAzOAe59nxvs8jAUHqV5diDCInnbQos4+cyFDXFzGq3lElot26A1yI+7Q==}
 
   '@zag-js/types@1.41.2':
     resolution: {integrity: sha512-L6CNvK06lIVpy0X8eG3kbDIx8Uuv+3KHElxXYSzRXSJ7/OLCv1sTRgEvnxNtdIWOrksGgxF4JtT7PXtoClGqNQ==}
@@ -2838,6 +2871,23 @@ snapshots:
       '@zag-js/types': 1.41.2
       '@zag-js/utils': 1.41.2
 
+  '@zag-js/collection@1.41.2':
+    dependencies:
+      '@zag-js/utils': 1.41.2
+
+  '@zag-js/combobox@1.41.2':
+    dependencies:
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/collection': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dismissable': 1.41.2
+      '@zag-js/dom-query': 1.41.2
+      '@zag-js/focus-visible': 1.41.2
+      '@zag-js/live-region': 1.41.2
+      '@zag-js/popper': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
   '@zag-js/core@1.41.2':
     dependencies:
       '@zag-js/dom-query': 1.41.2
@@ -2897,6 +2947,16 @@ snapshots:
       '@zag-js/dom-query': 1.41.2
       '@zag-js/utils': 1.41.2
 
+  '@zag-js/listbox@1.41.2':
+    dependencies:
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/collection': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dom-query': 1.41.2
+      '@zag-js/focus-visible': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
   '@zag-js/live-region@1.41.2': {}
 
   '@zag-js/menu@1.41.2':
@@ -2914,6 +2974,14 @@ snapshots:
   '@zag-js/number-input@1.41.2':
     dependencies:
       '@internationalized/number': 3.6.6
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dom-query': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
+  '@zag-js/pagination@1.41.2':
+    dependencies:
       '@zag-js/anatomy': 1.41.2
       '@zag-js/core': 1.41.2
       '@zag-js/dom-query': 1.41.2
@@ -2970,6 +3038,18 @@ snapshots:
   '@zag-js/remove-scroll@1.41.2':
     dependencies:
       '@zag-js/dom-query': 1.41.2
+
+  '@zag-js/select@1.41.2':
+    dependencies:
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/collection': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dismissable': 1.41.2
+      '@zag-js/dom-query': 1.41.2
+      '@zag-js/focus-visible': 1.41.2
+      '@zag-js/popper': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
 
   '@zag-js/slider@1.41.2':
     dependencies:
@@ -3043,6 +3123,15 @@ snapshots:
       '@zag-js/dom-query': 1.41.2
       '@zag-js/focus-visible': 1.41.2
       '@zag-js/popper': 1.41.2
+      '@zag-js/types': 1.41.2
+      '@zag-js/utils': 1.41.2
+
+  '@zag-js/tree-view@1.41.2':
+    dependencies:
+      '@zag-js/anatomy': 1.41.2
+      '@zag-js/collection': 1.41.2
+      '@zag-js/core': 1.41.2
+      '@zag-js/dom-query': 1.41.2
       '@zag-js/types': 1.41.2
       '@zag-js/utils': 1.41.2
 


### PR DESCRIPTION
Add Select, Combobox, Listbox, TreeView, and Pagination adapters over the @manti-ui/folds Zag machines. Select/Combobox/Listbox build a ListCollection; TreeView builds a TreeCollection and renders recursively; Pagination is collection-free. Token-backed CSS keyed to data-scope/data-part/data-state, with colocated stories. Completes Batch 4 of the zag-coverage tracker.