### PR TITLE
fix(tour): repair positioning, progress text, finish action, and a11y

### DIFF
--- a/packages/react/src/components/Tour/Tour.tsx
+++ b/packages/react/src/components/Tour/Tour.tsx
@@ -6,6 +6,14 @@ import { normalizeProps, Portal, useMachine } from '@zag-js/react';
 import { cx } from '../../internal/props';
 import { renderTrigger } from '../../internal/floating';
 
+/** Built-in navigation action a step button performs. */
+export type TourStepActionType = 'next' | 'prev' | 'dismiss' | 'skip';
+
+export interface TourStepAction {
+  label: string;
+  action: TourStepActionType;
+}
+
 export interface TourStep {
   id: string;
   /** CSS selector for the element to highlight. Omit for a centered step. */
@@ -14,12 +22,23 @@ export interface TourStep {
   description: string;
   placement?:
     | 'top'
-    | 'bottom'
-    | 'left'
-    | 'right'
     | 'top-start'
+    | 'top-end'
+    | 'bottom'
     | 'bottom-start'
+    | 'bottom-end'
+    | 'left'
+    | 'left-start'
+    | 'left-end'
+    | 'right'
+    | 'right-start'
+    | 'right-end'
     | 'center';
+  /**
+   * Action buttons for this step. Defaults to Back/Next, with the first step
+   * dropping Back and the last step finishing the tour ("Done").
+   */
+  actions?: TourStepAction[];
 }
 
 export interface TourProps {
@@ -31,22 +50,39 @@ export interface TourProps {
   className?: string;
 }
 
-const defaultActions = [
-  { label: 'Back', action: 'prev' as const },
-  { label: 'Next', action: 'next' as const },
-];
+/**
+ * Sensible per-step defaults: Back appears on every step except the first;
+ * the last step finishes the tour via `dismiss` (Zag disables `next` on the
+ * last step), every other step advances with Next.
+ */
+function defaultStepActions(index: number, total: number): TourStepAction[] {
+  const actions: TourStepAction[] = [];
+  if (index > 0) actions.push({ label: 'Back', action: 'prev' });
+  actions.push(
+    index === total - 1
+      ? { label: 'Done', action: 'dismiss' }
+      : { label: 'Next', action: 'next' },
+  );
+  return actions;
+}
 
 /** A guided product tour backed by the Zag.js tour machine. */
 export function Tour({ steps, trigger, id, className }: TourProps) {
   const autoId = useId();
   const resolvedSteps = useMemo(
     () =>
-      steps.map((step) => ({
+      steps.map((step, index) => ({
         id: step.id,
+        // Zag requires a target or an explicit type; a targetless step is a
+        // centered dialog, so tag it as such (otherwise Zag logs an error).
+        // Targeted steps must OMIT `type` entirely — Zag's normalizeStep does
+        // `{ type: 'tooltip', ...step }`, so a literal `type: undefined` would
+        // overwrite the inferred 'tooltip' and silently disable the popper.
+        ...(step.target ? null : { type: 'dialog' as const }),
         title: step.title,
         description: step.description,
         placement: step.placement,
-        actions: defaultActions,
+        actions: step.actions ?? defaultStepActions(index, steps.length),
         target: step.target
           ? () => document.querySelector<HTMLElement>(step.target as string)
           : undefined,
@@ -56,6 +92,9 @@ export function Tour({ steps, trigger, id, className }: TourProps) {
   const service = useMachine(tour.machine, {
     id: id ?? autoId,
     steps: resolvedSteps,
+    translations: {
+      progressText: ({ current, total }) => `${current + 1} of ${total}`,
+    },
   });
   const api = tour.connect(service, normalizeProps);
   const step = api.step;
@@ -69,7 +108,7 @@ export function Tour({ steps, trigger, id, className }: TourProps) {
           <div {...api.getSpotlightProps()} />
           <div {...api.getPositionerProps()}>
             <div {...api.getContentProps()} className={cx(className)}>
-              <p {...api.getProgressTextProps()} />
+              <p {...api.getProgressTextProps()}>{api.getProgressText()}</p>
               <p {...api.getTitleProps()}>{step.title}</p>
               <p {...api.getDescriptionProps()}>{step.description}</p>
               <div {...api.getArrowProps()}>
@@ -91,10 +130,14 @@ export function Tour({ steps, trigger, id, className }: TourProps) {
                 </svg>
               </button>
               <div data-part="actions">
-                {(step.actions ?? defaultActions).map((action) => (
+                {(step.actions ?? []).map((action) => (
                   <button
                     key={action.label}
                     {...api.getActionTriggerProps({ action })}
+                    // Zag forces the dismiss action's aria-label to its "close"
+                    // translation; keep the accessible name matching the
+                    // visible label (WCAG 2.5.3).
+                    aria-label={action.label}
                   >
                     {action.label}
                   </button>

--- a/packages/styles/src/components/tour.css
+++ b/packages/styles/src/components/tour.css
@@ -15,11 +15,30 @@
     position: absolute;
     border-radius: var(--manti-radius-md);
     box-shadow: 0 0 0 9999px var(--manti-overlay);
-    z-index: var(--manti-z-modal);
+    /* Layer order (Zag --tour-layer): backdrop 0 < spotlight 1 < positioner 2. */
+    z-index: calc(var(--manti-z-modal) + 1);
   }
 
+  /*
+   * The positioner must paint above the backdrop so its content card is
+   * interactive. Zag's popper writes an inline `z-index: var(--z-index)` on the
+   * positioner (with `--z-index: auto` on centered/dialog steps, where popper
+   * never runs to fill it). An inline declaration beats any layered rule, so
+   * `!important` is the only way to lift the card above the backdrop here.
+   */
   [data-scope='tour'][data-part='positioner'] {
-    z-index: var(--manti-z-modal);
+    z-index: calc(var(--manti-z-modal) + 2) !important;
+  }
+
+  /*
+   * A dialog (centered) step gets no inline position from popper, so it would
+   * fall back to `static`. Pin it to the viewport and center the card.
+   */
+  [data-scope='tour'][data-part='positioner'][data-type='dialog'] {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
   }
 
   [data-scope='tour'][data-part='content'] {


### PR DESCRIPTION
The Tour adapter left the Zag tour machine half-wired:

- Targeted steps passed `type: undefined`, which Zag's normalizeStep (`{ type: 'tooltip', ...step }`) spread back over the inferred 'tooltip', disabling the popper so the spotlight/tooltip never positioned. Omit `type` for targeted steps; tag only targetless (centered) steps as 'dialog'.
- Progress text was never rendered and no `progressText` translation was supplied, so the "N of M" indicator was always empty.
- The last step's "Next" was disabled with no way to finish; steps now finish with a "Done" (dismiss) action and drop "Back" on the first.
- The content card sat under the backdrop (Zag writes an inline `z-index: var(--z-index)`); lift the positioner above it and center the dialog (centered) step.
- The dismiss action inherited the "close" aria-label; keep the accessible name matching the visible label (WCAG 2.5.3).
- Expand the public placement union to the full popper set.