### PR TITLE
fix(styles): make floating panel overlays opaque enough to stay legible

### DIFF
--- a/packages/styles/src/tokens.css
+++ b/packages/styles/src/tokens.css
@@ -256,8 +256,8 @@
       oklch(0.2 0.008 280 / 0.55)
     );
     --manti-panel-tint-strong: light-dark(
-      oklch(0.995 0.0015 280 / 0.86),
-      oklch(0.22 0.009 280 / 0.82)
+      oklch(0.995 0.0015 280 / 0.94),
+      oklch(0.22 0.009 280 / 0.93)
     );
     --manti-panel-blur: blur(12px) saturate(140%);
     --manti-panel-border: light-dark(


### PR DESCRIPTION
## Problem
Open a floating overlay (combobox listbox, menu, select, popover, tooltip,
hover-card, date/time picker, dialog…) over busy or colourful content and the
content behind **bled through** the panel — most visibly in the docs, where the
React/Vue/Svelte/Solid framework switcher showed through an open combobox
listbox. It reads as if the toolbar sits *on top of* the dropdown, but the panel
is correctly on top (portalled, `z-index: --manti-z-popover`) — it was just too
translucent.

## Fix
`--manti-panel-tint-strong` is the shared surface for **every** floating overlay.
Raise its opacity from dark **82% / light 86%** → dark **93% / light 94%**. The
frosted `backdrop-filter` blur stays, so the material still reads as a panel, but
content behind no longer shows through and overlays stay legible on any
background.

In-page soft surfaces (cards, tabs tracks, toggles, segmented controls) keep the
lighter `--manti-panel-tint` on purpose — they sit over the calm page background,
not over arbitrary content, so they were never part of the bleed-through.

## Verification
`pnpm verify` green. New value confirmed in `dist/index.css`
(`light-dark(oklch(99.5% … /.94), oklch(22% … /.93))`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)