### PR TITLE
fix(docs): opaque floating overlays + combobox/select scroll-area, carousel & file-upload polish

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -25,6 +25,16 @@ const config: StorybookConfig = {
   async viteFinal(viteConfig) {
     const { mergeConfig } = await import('vite');
     return mergeConfig(viteConfig, {
+      server: {
+        watch: {
+          // Manti packages are symlinked into node_modules, so their source is
+          // reached via `node_modules/@manti-ui/*` — which Vite's watcher
+          // ignores by default. Un-ignore it so edits to packages/*/src HMR live
+          // here without a restart. (The `development` export condition already
+          // serves src, not dist, so no rebuild step is needed.)
+          ignored: ['!**/node_modules/@manti-ui/**'],
+        },
+      },
       css: {
         transformer: 'lightningcss',
         lightningcss: { targets: evergreen },

--- a/docs/component-tokens.md
+++ b/docs/component-tokens.md
@@ -25,6 +25,7 @@ component token only to make one component diverge on purpose — see
 | `button`            | `--manti-button-font-size`                  | `var(--manti-text-sm)`           |
 | `button`            | `--manti-button-gap`                        | `var(--manti-space-2)`           |
 | `carousel`          | `--manti-carousel-viewport-height`          | `22rem`                          |
+| `carousel`          | `--manti-carousel-slide-gap`                | `var(--manti-space-3)`           |
 | `checkbox`          | `--manti-checkbox-size`                     | `1.25rem`                        |
 | `clipboard`         | `--manti-clipboard-height`                  | `var(--manti-control-height-md)` |
 | `color-picker`      | `--manti-color-picker-height`               | `var(--manti-control-height-md)` |

--- a/packages/docs/src/content/components/carousel.mdx
+++ b/packages/docs/src/content/components/carousel.mdx
@@ -12,21 +12,21 @@ A slide carousel backed by the Zag.js carousel machine. Pass a `slides` array an
 the machine owns scroll-snapping, drag, keyboard navigation, and the page
 indicators.
 
-<Demo name="carousel/basic" />
+<Demo name="carousel/basic" center />
 
 ## Basic
 
 Each entry in `slides` is rendered as one slide. Use the arrows, the indicator
 dots, or swipe to move between pages.
 
-<Demo name="carousel/basic" />
+<Demo name="carousel/basic" center />
 
 ## Multiple per page
 
 Set `slidesPerPage` to show several slides at once, and `loop` to wrap from the
 last page back to the first.
 
-<Demo name="carousel/multiple" />
+<Demo name="carousel/multiple" center />
 
 ## Props
 

--- a/packages/docs/src/content/components/file-upload.mdx
+++ b/packages/docs/src/content/components/file-upload.mdx
@@ -12,21 +12,21 @@ A file dropzone with a browse button and a list of accepted files, backed by the
 Zag.js file-upload machine. Constrain selection with `accept`, `maxFiles`, and
 `maxFileSize`.
 
-<Demo name="file-upload/basic" />
+<Demo name="file-upload/basic" center />
 
 ## Basic
 
 Drop files onto the zone or use the browse button. Accepted files appear as
 removable rows below.
 
-<Demo name="file-upload/basic" />
+<Demo name="file-upload/basic" center />
 
 ## Restricting types
 
 `accept` limits the file picker and drop validation — here, images only, capped
 at three files.
 
-<Demo name="file-upload/images-only" />
+<Demo name="file-upload/images-only" center />
 
 ## Props
 

--- a/packages/docs/src/demos/carousel/basic.tsx
+++ b/packages/docs/src/demos/carousel/basic.tsx
@@ -7,7 +7,7 @@ const slide = (label: string) => (
       placeItems: 'center',
       height: 'calc(var(--manti-space-16) * 3)',
       borderRadius: 'var(--manti-radius-lg)',
-      background: 'var(--manti-surface)',
+      background: 'var(--manti-surface-raised)',
       color: 'var(--manti-text)',
       fontSize: 'var(--manti-text-xl)',
       fontWeight: 'var(--manti-weight-semibold)',

--- a/packages/docs/src/demos/carousel/multiple.tsx
+++ b/packages/docs/src/demos/carousel/multiple.tsx
@@ -7,7 +7,7 @@ const slide = (label: string) => (
       placeItems: 'center',
       height: 'calc(var(--manti-space-16) * 3)',
       borderRadius: 'var(--manti-radius-lg)',
-      background: 'var(--manti-surface)',
+      background: 'var(--manti-surface-raised)',
       color: 'var(--manti-text)',
       fontSize: 'var(--manti-text-lg)',
       fontWeight: 'var(--manti-weight-semibold)',

--- a/packages/docs/src/styles/docs.css
+++ b/packages/docs/src/styles/docs.css
@@ -23,9 +23,6 @@
     --docs-prose-max: 48rem;
     --docs-gutter: var(--manti-space-6);
 
-    /* A much more see-through translucent tint than --manti-panel-tint (which sits
-       at ~0.55 alpha), tuned for the sticky header so content reads through it.
-       Authored as light-dark like the Manti panel tokens themselves. */
     --docs-nav-bg: light-dark(
       oklch(0.99 0.002 280 / 0.42),
       oklch(0.17 0.008 280 / 0.42)
@@ -64,10 +61,6 @@
     height: var(--docs-nav-h);
     padding-inline: var(--docs-gutter);
     background: var(--docs-nav-bg);
-    /* -webkit first, then unprefixed — matches the Manti panel components.
-       The reverse order makes Lightning CSS drop the unprefixed property, and
-       Chrome/Firefox don't apply `-webkit-backdrop-filter` with a var() value,
-       so the blur silently disappears. */
     -webkit-backdrop-filter: var(--docs-nav-blur);
     backdrop-filter: var(--docs-nav-blur);
     border-bottom: 1px solid var(--manti-panel-border);
@@ -148,8 +141,7 @@
     top: var(--docs-nav-h);
     height: calc(100dvh - var(--docs-nav-h));
   }
-  /* The nav scrolls inside a Manti ScrollArea (custom, auto-hiding scrollbar)
-     rather than the aside's native overflow. */
+
   .docs-sidebar-scroll {
     height: 100%;
   }
@@ -306,8 +298,7 @@
   .docs-prose li::marker {
     color: var(--manti-text-subtle);
   }
-  /* Inline prose links only — not wrapper links like the component cards
-     (`.docs-plain`), which must never pick up the underline or link color. */
+
   .docs-prose a:not(.docs-plain) {
     color: var(--manti-link);
     text-decoration: none;
@@ -436,12 +427,7 @@
   .docs-demo-canvas.is-center {
     justify-content: center;
   }
-  /* Live demos render real component markup. Headings, paragraphs and lists in
-     that markup (e.g. an Accordion trigger's <h3>, which opened large top gaps)
-     must not inherit the prose typography defined above. `revert-layer` rolls
-     these back past the entire `docs` layer, so demo content falls through to
-     each component's own styles (manti.components) or the reset (manti.reset)
-     instead of the prose rules — without clobbering component typography. */
+
   .docs-demo-canvas :is(h1, h2, h3, h4, h5, h6) {
     margin: revert-layer;
     font-size: revert-layer;
@@ -450,6 +436,7 @@
   }
   .docs-demo-canvas :is(p, ul, ol, li) {
     margin: revert-layer;
+    padding: revert-layer;
   }
   .docs-demo-bar {
     display: flex;
@@ -462,8 +449,7 @@
     display: flex;
     align-items: center;
   }
-  /* The framework switcher is a Manti soft Tabs with its content panels hidden —
-     only the trigger row belongs in the toolbar. */
+
   .docs-demo-frameworks [data-scope='tabs'][data-part='root'] {
     gap: 0;
   }
@@ -479,8 +465,6 @@
     width: 1.15em;
     height: 1.15em;
   }
-  /* Active framework wears its own brand color (set inline via --fw-color);
-     wins over Manti's selected color by cascade-layer order (docs > components). */
   .docs-demo-frameworks [data-part='trigger'][data-selected] {
     color: var(--fw-color);
   }
@@ -490,9 +474,6 @@
   .docs-demo pre.shiki {
     border: none;
     border-radius: 0;
-    /* Match the preview canvas background instead of Shiki's own theme bg, so
-       the demo reads as one surface. Wins over both the light and dark
-       `pre.shiki` background rules (equal specificity, declared later). */
     background-color: var(--manti-bg-subtle);
   }
 
@@ -509,8 +490,7 @@
     color: inherit;
     text-decoration: none;
   }
-  /* Every catalog card fills its equal-height grid cell, so cards line up
-     regardless of how long each summary is. */
+  
   .docs-card-grid .docs-plain,
   .docs-card-grid .docs-plain > * {
     height: 100%;
@@ -662,8 +642,6 @@
     color: var(--manti-text-subtle);
   }
 
-  /* The native search clear (X). Replace the default glyph with a recolorable
-     mask so it can be gray by default and white on hover, with a pointer. */
   .docs-search-field input[type='search']::-webkit-search-cancel-button {
     -webkit-appearance: none;
     appearance: none;

--- a/packages/react/src/components/Carousel/Carousel.tsx
+++ b/packages/react/src/components/Carousel/Carousel.tsx
@@ -64,6 +64,10 @@ export function Carousel({
     id: id ?? autoId,
     slideCount: slides.length,
     slidesPerPage,
+    // Gap between slides. Zag wires this into both the flex `gap` and each
+    // slide's width math, so it must come through the machine (a CSS `gap`
+    // would be overridden). Defaults to the --manti-carousel-slide-gap token.
+    spacing: 'var(--manti-carousel-slide-gap)',
     orientation,
     allowMouseDrag: mouseDrag,
     loop,

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -6,6 +6,7 @@ import { normalizeProps, Portal, useMachine } from '@zag-js/react';
 
 import { cx } from '../../internal/props';
 import type { Placement } from '../../internal/floating';
+import { ScrollArea } from '../ScrollArea/ScrollArea';
 
 export interface ComboboxItem {
   value: string;
@@ -104,6 +105,11 @@ export function Combobox({
     required,
     name,
     positioning: { placement, sameWidth: true },
+    // The listbox scrolls inside a Manti ScrollArea (the `ul` no longer scrolls
+    // itself), so override Zag's default scroll-into-view: native scrollIntoView
+    // walks up to the ScrollArea viewport — the nearest scrollable ancestor.
+    scrollToIndexFn: (details) =>
+      details.getElement()?.scrollIntoView({ block: 'nearest' }),
     onInputValueChange: (details) => setQuery(details.inputValue),
     onValueChange: onValueChange
       ? (details) => onValueChange(details.value)
@@ -136,14 +142,16 @@ export function Combobox({
       </div>
       <Portal>
         <div {...api.getPositionerProps()}>
-          <ul {...api.getContentProps()}>
-            {filtered.map((item) => (
-              <li key={item.value} {...api.getItemProps({ item })}>
-                <span {...api.getItemTextProps({ item })}>{item.label}</span>
-                <span {...api.getItemIndicatorProps({ item })}>{check}</span>
-              </li>
-            ))}
-          </ul>
+          <ScrollArea focusable={false}>
+            <ul {...api.getContentProps()}>
+              {filtered.map((item) => (
+                <li key={item.value} {...api.getItemProps({ item })}>
+                  <span {...api.getItemTextProps({ item })}>{item.label}</span>
+                  <span {...api.getItemIndicatorProps({ item })}>{check}</span>
+                </li>
+              ))}
+            </ul>
+          </ScrollArea>
         </div>
       </Portal>
     </div>

--- a/packages/react/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react/src/components/FileUpload/FileUpload.tsx
@@ -75,7 +75,9 @@ export function FileUpload({
               {...api.getItemProps({ file })}
             >
               <span {...api.getItemNameProps({ file })}>{file.name}</span>
-              <span {...api.getItemSizeTextProps({ file })} />
+              <span {...api.getItemSizeTextProps({ file })}>
+                {api.getFileSize(file)}
+              </span>
               <button
                 {...api.getItemDeleteTriggerProps({ file })}
                 aria-label={`Remove ${file.name}`}

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -6,6 +6,7 @@ import { normalizeProps, Portal, useMachine } from '@zag-js/react';
 
 import { cx } from '../../internal/props';
 import type { Placement } from '../../internal/floating';
+import { ScrollArea } from '../ScrollArea/ScrollArea';
 
 export interface SelectItem {
   value: string;
@@ -99,6 +100,11 @@ export function Select({
     required,
     name,
     positioning: { placement, sameWidth: true },
+    // The listbox scrolls inside a Manti ScrollArea, so override Zag's default
+    // scroll-into-view: native scrollIntoView walks up to the ScrollArea
+    // viewport — the nearest scrollable ancestor.
+    scrollToIndexFn: (details) =>
+      details.getElement()?.scrollIntoView({ block: 'nearest' }),
     onValueChange: onValueChange
       ? (details) => onValueChange(details.value)
       : undefined,
@@ -137,14 +143,16 @@ export function Select({
       </div>
       <Portal>
         <div {...api.getPositionerProps()}>
-          <ul {...api.getContentProps()}>
-            {items.map((item) => (
-              <li key={item.value} {...api.getItemProps({ item })}>
-                <span {...api.getItemTextProps({ item })}>{item.label}</span>
-                <span {...api.getItemIndicatorProps({ item })}>{check}</span>
-              </li>
-            ))}
-          </ul>
+          <ScrollArea focusable={false}>
+            <ul {...api.getContentProps()}>
+              {items.map((item) => (
+                <li key={item.value} {...api.getItemProps({ item })}>
+                  <span {...api.getItemTextProps({ item })}>{item.label}</span>
+                  <span {...api.getItemIndicatorProps({ item })}>{check}</span>
+                </li>
+              ))}
+            </ul>
+          </ScrollArea>
         </div>
       </Portal>
       <select {...api.getHiddenSelectProps()}>

--- a/packages/styles/src/base.css
+++ b/packages/styles/src/base.css
@@ -63,8 +63,25 @@
     }
   }
 
+  /* Floating panels (dropdowns, menus, popovers, tooltips, date/color pickers)
+     render inside a `positioner` that the positioning engine transforms with an
+     inline `translate(...)`. A transformed ancestor severs `backdrop-filter`
+     from the page backdrop, so the frosted blur can't reach the content behind
+     the panel — a translucent surface then bleeds that content through sharply
+     instead of frosting it. Inside any positioner, swap the panel material for
+     an opaque surface so floating panels stay legible over scrolling content.
+     Non-floating panels (cards, inline controls) are untouched and keep the
+     translucent glass, where the blur genuinely works. */
+  [data-part='positioner'] {
+    --manti-panel-tint-strong: var(--manti-surface-raised);
+  }
+
+  /* Text selection picks up the primary accent — the one deliberate spot of
+     brand colour outside the semantic tones. Mirrors how the primary tone
+     resolves its solid (orange-600 in light, orange-500 in dark). */
   ::selection {
-    background: color-mix(in oklab, var(--manti-text) 18%, transparent);
+    background: var(--manti-selection-bg);
+    color: var(--manti-selection-text);
   }
 
   :where(.manti-app) a {

--- a/packages/styles/src/components/carousel.css
+++ b/packages/styles/src/components/carousel.css
@@ -4,14 +4,21 @@
  */
 @layer manti.components {
   [data-scope='carousel'][data-part='root'] {
+    /* Component tokens (Tier 3) — public per-component override surface; default to semantic tokens. See docs/styling.md. */
+    --manti-carousel-slide-gap: var(--manti-space-3);
+
     display: flex;
     flex-direction: column;
     gap: var(--manti-space-3);
   }
 
+  /* Gap between slides comes from Zag's `spacing` machine prop (wired to
+     --manti-carousel-slide-gap in the renderer): Zag inline-sets the flex `gap`
+     AND subtracts the same value from each slide's width, so a plain CSS `gap`
+     here would be overridden and break the width math. Override the gap only
+     through the component token. */
   [data-scope='carousel'][data-part='item-group'] {
     display: flex;
-    gap: var(--manti-space-3);
     overflow: hidden;
 
     &[data-orientation='vertical'] {

--- a/packages/styles/src/components/color-picker.css
+++ b/packages/styles/src/components/color-picker.css
@@ -52,7 +52,7 @@
   }
 
   [data-scope='color-picker'][data-part='positioner'] {
-    z-index: var(--manti-z-popover);
+    z-index: var(--manti-z-popover) !important;
   }
 
   [data-scope='color-picker'][data-part='content'] {

--- a/packages/styles/src/components/combobox.css
+++ b/packages/styles/src/components/combobox.css
@@ -107,18 +107,20 @@
   }
 
   [data-scope='combobox'][data-part='positioner'] {
-    z-index: var(--manti-z-popover);
+    z-index: var(--manti-z-popover) !important;
   }
 
-  [data-scope='combobox'][data-part='content'] {
+  /* The listbox scrolls inside a Manti ScrollArea (auto-hiding, grabbable
+     thumb). The frosted panel frame lives on the scroll-area root; the height
+     bound goes on the viewport (the actual scroll container — `height: 100%`
+     can't resolve against a max-height-only root, so the bound must sit on the
+     element that scrolls). The `ul` just lays out the items. Zag's keyboard
+     scroll-into-view is rewired via `scrollToIndexFn` in the React adapter. */
+  [data-scope='combobox'][data-part='positioner']
+    [data-scope='scroll-area'][data-part='root'] {
     --manti-combobox-content-max-height: 18rem;
 
-    display: flex;
-    flex-direction: column;
-    gap: var(--manti-space-1);
-    max-height: var(--manti-combobox-content-max-height);
-    overflow-y: auto;
-    padding: var(--manti-space-2);
+    width: 100%;
     background: var(--manti-panel-tint-strong);
     -webkit-backdrop-filter: var(--manti-panel-blur);
     backdrop-filter: var(--manti-panel-blur);
@@ -127,20 +129,37 @@
     box-shadow:
       inset 0 1px 0 0 var(--manti-panel-highlight),
       var(--manti-panel-shadow);
+  }
+
+  [data-scope='combobox'][data-part='positioner']
+    [data-scope='scroll-area'][data-part='viewport'] {
+    max-height: var(--manti-combobox-content-max-height);
+  }
+
+  /* No matches → the `ul` renders empty; hide the whole panel. */
+  [data-scope='combobox'][data-part='positioner']
+    [data-scope='scroll-area'][data-part='root']:has(
+      [data-part='content']:empty
+    ) {
+    display: none;
+  }
+
+  [data-scope='combobox'][data-part='content'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-1);
+    padding: var(--manti-space-2);
 
     &:focus-visible {
       outline: none;
-    }
-
-    &:empty {
-      display: none;
     }
   }
 
   @supports not (
     (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
   ) {
-    [data-scope='combobox'][data-part='content'] {
+    [data-scope='combobox'][data-part='positioner']
+      [data-scope='scroll-area'][data-part='root'] {
       background: var(--manti-surface-raised);
     }
   }

--- a/packages/styles/src/components/date-picker.css
+++ b/packages/styles/src/components/date-picker.css
@@ -70,7 +70,7 @@
   }
 
   [data-scope='date-picker'][data-part='positioner'] {
-    z-index: var(--manti-z-popover);
+    z-index: var(--manti-z-popover) !important;
   }
 
   [data-scope='date-picker'][data-part='content'] {

--- a/packages/styles/src/components/file-upload.css
+++ b/packages/styles/src/components/file-upload.css
@@ -78,6 +78,10 @@
   }
 
   [data-scope='file-upload'][data-part='item-group'] {
+    /* This part is a <ul>; the reset only zeroes margin, so clear the browser's
+       default list padding-inline-start and marker to avoid a stray left gap. */
+    list-style: none;
+    padding: 0;
     display: flex;
     flex-direction: column;
     gap: var(--manti-space-2);
@@ -109,17 +113,34 @@
     font-variant-numeric: tabular-nums;
   }
 
+  /* Matches the canonical close-trigger anatomy (dialog/drawer/popover/toast):
+     a square, radius-sm icon button that tints its background on hover. Keeps
+     the dismiss affordance consistent across the system. */
   [data-scope='file-upload'][data-part='item-delete-trigger'] {
     display: inline-flex;
     flex: none;
     align-items: center;
     justify-content: center;
+    width: var(--manti-space-6);
+    height: var(--manti-space-6);
+    padding: 0;
     color: var(--manti-text-muted);
+    background: transparent;
+    border: 0;
+    border-radius: var(--manti-radius-sm);
     cursor: pointer;
-    transition: color var(--manti-duration-fast) var(--manti-ease-smooth);
+    transition:
+      background var(--manti-duration-fast) var(--manti-ease-soft),
+      color var(--manti-duration-fast) var(--manti-ease-soft);
 
     &:hover {
-      color: light-dark(var(--manti-red-600), var(--manti-red-400));
+      background: color-mix(in oklab, var(--manti-text) 8%, transparent);
+      color: var(--manti-text);
+    }
+
+    &:focus-visible {
+      outline: var(--manti-focus-ring-width) solid var(--tone-ring);
+      outline-offset: calc(var(--manti-focus-ring-offset) * -1);
     }
   }
 }

--- a/packages/styles/src/components/hover-card.css
+++ b/packages/styles/src/components/hover-card.css
@@ -5,7 +5,7 @@
  */
 @layer manti.components {
   [data-scope='hover-card'][data-part='positioner'] {
-    z-index: var(--manti-z-popover);
+    z-index: var(--manti-z-popover) !important;
   }
 
   [data-scope='hover-card'][data-part='content'] {

--- a/packages/styles/src/components/menu.css
+++ b/packages/styles/src/components/menu.css
@@ -4,7 +4,7 @@
  */
 @layer manti.components {
   [data-scope='menu'][data-part='positioner'] {
-    z-index: var(--manti-z-popover);
+    z-index: var(--manti-z-popover) !important;
   }
 
   [data-scope='menu'][data-part='content'] {

--- a/packages/styles/src/components/popover.css
+++ b/packages/styles/src/components/popover.css
@@ -4,7 +4,7 @@
  */
 @layer manti.components {
   [data-scope='popover'][data-part='positioner'] {
-    z-index: var(--manti-z-popover);
+    z-index: var(--manti-z-popover) !important;
   }
 
   [data-scope='popover'][data-part='content'] {

--- a/packages/styles/src/components/select.css
+++ b/packages/styles/src/components/select.css
@@ -109,18 +109,20 @@
   }
 
   [data-scope='select'][data-part='positioner'] {
-    z-index: var(--manti-z-popover);
+    z-index: var(--manti-z-popover) !important;
   }
 
-  [data-scope='select'][data-part='content'] {
+  /* The listbox scrolls inside a Manti ScrollArea (auto-hiding, grabbable
+     thumb). The frosted panel frame lives on the scroll-area root; the height
+     bound goes on the viewport (the actual scroll container — `height: 100%`
+     can't resolve against a max-height-only root, so the bound must sit on the
+     element that scrolls). The `ul` just lays out the items. Zag's keyboard
+     scroll-into-view is rewired via `scrollToIndexFn` in the React adapter. */
+  [data-scope='select'][data-part='positioner']
+    [data-scope='scroll-area'][data-part='root'] {
     --manti-select-content-max-height: 18rem;
 
-    display: flex;
-    flex-direction: column;
-    gap: var(--manti-space-1);
-    max-height: var(--manti-select-content-max-height);
-    overflow-y: auto;
-    padding: var(--manti-space-2);
+    width: 100%;
     background: var(--manti-panel-tint-strong);
     -webkit-backdrop-filter: var(--manti-panel-blur);
     backdrop-filter: var(--manti-panel-blur);
@@ -129,6 +131,18 @@
     box-shadow:
       inset 0 1px 0 0 var(--manti-panel-highlight),
       var(--manti-panel-shadow);
+  }
+
+  [data-scope='select'][data-part='positioner']
+    [data-scope='scroll-area'][data-part='viewport'] {
+    max-height: var(--manti-select-content-max-height);
+  }
+
+  [data-scope='select'][data-part='content'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--manti-space-1);
+    padding: var(--manti-space-2);
 
     &:focus-visible {
       outline: none;
@@ -138,7 +152,8 @@
   @supports not (
     (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
   ) {
-    [data-scope='select'][data-part='content'] {
+    [data-scope='select'][data-part='positioner']
+      [data-scope='scroll-area'][data-part='root'] {
       background: var(--manti-surface-raised);
     }
   }

--- a/packages/styles/src/components/time-picker.css
+++ b/packages/styles/src/components/time-picker.css
@@ -70,7 +70,7 @@
   }
 
   [data-scope='time-picker'][data-part='positioner'] {
-    z-index: var(--manti-z-popover);
+    z-index: var(--manti-z-popover) !important;
   }
 
   [data-scope='time-picker'][data-part='content'] {

--- a/packages/styles/src/components/tooltip.css
+++ b/packages/styles/src/components/tooltip.css
@@ -9,7 +9,7 @@
   }
 
   [data-scope='tooltip'][data-part='positioner'] {
-    z-index: var(--manti-z-popover);
+    z-index: var(--manti-z-popover) !important;
   }
 
   [data-scope='tooltip'][data-part='content'] {

--- a/packages/styles/src/tokens.css
+++ b/packages/styles/src/tokens.css
@@ -232,6 +232,12 @@
     --manti-focus-ring-width: 3px;
     --manti-focus-ring-offset: 2px;
 
+    /* Text selection — the one deliberate brand-coloured accent (consumed by
+       `::selection` in base.css). Hand-authored, not part of the generated
+       region above. */
+    --manti-selection-bg: var(--manti-orange-500);
+    --manti-selection-text: var(--manti-gray-950);
+
     /* Elevation ---------------------------------------------------------- */
     --manti-shadow-sm: light-dark(
       0 1px 2px -1px oklch(0.2 0.03 280 / 0.1),

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -271,7 +271,7 @@ export const componentTokens = {
   switch: ['track-width', 'track-height', 'track-padding'],
   avatar: ['size'],
   badge: ['font-size', 'padding-x', 'padding-y'],
-  carousel: ['viewport-height'],
+  carousel: ['viewport-height', 'slide-gap'],
   checkbox: ['size'],
   clipboard: ['height'],
   'color-picker': ['height', 'panel-width', 'area-height'],


### PR DESCRIPTION
## What & why

Fixes the docs playground bug where the framework tabs (React/Vue/Svelte/Solid)
bled through the floating overlays of HoverCard, Combobox, Select and DatePicker,
plus a few related polish items batched onto the same hotfix branch.

### Root cause of the overlay bleed
Floating panels render inside a Zag positioner that gets an inline `transform:
translate()`. A transformed ancestor severs `backdrop-filter` from the page
backdrop, so the frosted blur never reaches the content behind the panel and the
translucent panel tint let the tabs show through sharply. The panel was already
on top (portaled, `z-index: 1100`) — it was see-through, not behind. Fix: swap
the panel material for an opaque `--manti-surface-raised` inside any
`[data-part='positioner']`; non-floating glass (cards) keep the translucent
material where the blur genuinely works.

## Commits
- **fix(styles):** opaque overlay panels inside any `[data-part='positioner']`
  (+ pinned popover z-index, + brand `::selection` accent)
- **feat(combobox,select):** listbox scrolls inside a Manti ScrollArea
- **feat(carousel):** `--manti-carousel-slide-gap` component token
- **fix(file-upload):** square delete trigger, render file sizes, flush rows
- **chore(docs):** tidy docs.css comments, HMR symlinked Manti src in Storybook

## Verification
`pnpm verify` green (lint + typecheck + build + Storybook). dist rebuilt for
`@manti-ui/{tokens,styles,react}` so the production docs build picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
