### PR TITLE
ci: add release workflow (npm publish + GitHub Release on v* tags)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+# Publishes the public @manti-ui/* packages to npm and opens a GitHub Release
+# whenever a version tag (v*) is pushed.
+#
+# Cutting a release:
+#   1. Bump the package versions (e.g. all packages 0.1.1 -> 0.1.2) and commit.
+#   2. git tag v0.1.2 && git push origin v0.1.2
+#
+# Prerequisite: an `NPM_TOKEN` repository secret holding an npm automation token
+# with publish rights to the @manti-ui scope. Without it the publish step fails.
+# (Settings -> Secrets and variables -> Actions -> New repository secret.)
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Never run two releases for the same tag at once; don't cancel an in-flight one.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create the GitHub Release + read history for notes
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so release notes can diff against the last tag
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4 # version comes from package.json "packageManager"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build:packages
+
+      # Publishes every non-private workspace package (tokens, styles, folds,
+      # react) in dependency order; `workspace:*` ranges are rewritten to the
+      # real version by pnpm. Private packages (docs, the root) are skipped.
+      - name: Publish to npm
+        run: pnpm -r publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" --verify-tag --generate-notes


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — the missing automation behind the repo's **Releases** section and npm versioning.

## How it works

Pushing a version tag (`v*`) runs the workflow, which:

1. Installs deps + builds the packages (`pnpm build:packages`)
2. Publishes the public `@manti-ui/*` packages to **npmjs.com** in dependency order (`pnpm -r publish` — private packages like `docs` are skipped, `workspace:*` ranges are rewritten to the real version)
3. Creates a **GitHub Release** for the tag with auto-generated notes

### Cutting a release

```bash
# bump versions across packages, commit, then:
git tag v0.1.2
git push origin v0.1.2
```

## ⚠️ Required setup before first use

Add an **`NPM_TOKEN`** repository secret (npm *automation* token with publish rights to the `@manti-ui` scope):
`Settings → Secrets and variables → Actions → New repository secret`

Without it, the publish step fails.

## Notes

- The current npm release (`v0.1.0`) is backfilled as a GitHub Release separately, so the Releases section is populated immediately.
- Targets `dev` per the repo's branch convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)