### PR TITLE
feat(data-table): TanStack-backed DataTable + sidebar categorization & collapsible groups

### DIFF
--- a/docs/component-tokens.md
+++ b/docs/component-tokens.md
@@ -33,6 +33,11 @@ component token only to make one component diverge on purpose — see
 | `color-picker`      | `--manti-color-picker-area-height`          | `9rem`                           |
 | `combobox`          | `--manti-combobox-height`                   | `var(--manti-control-height-md)` |
 | `combobox`          | `--manti-combobox-content-max-height`       | `18rem`                          |
+| `data-table`        | `--manti-data-table-radius`                 | `var(--manti-radius-lg)`         |
+| `data-table`        | `--manti-data-table-cell-padding-x`         | `var(--manti-space-4)`           |
+| `data-table`        | `--manti-data-table-cell-padding-y`         | `var(--manti-space-3)`           |
+| `data-table`        | `--manti-data-table-font-size`              | `var(--manti-text-sm)`           |
+| `data-table`        | `--manti-data-table-header-font-size`       | `var(--manti-text-xs)`           |
 | `date-picker`       | `--manti-date-picker-height`                | `var(--manti-control-height-md)` |
 | `dialog`            | `--manti-dialog-max-width`                  | `32rem`                          |
 | `drawer`            | `--manti-drawer-size`                       | `24rem`                          |

--- a/packages/docs/index.html
+++ b/packages/docs/index.html
@@ -14,10 +14,10 @@
     <!-- Managed block: vite-plugin-seo regenerates this per route at build time
          (see src/seo/vite-plugin-seo.ts). The values below are the home-route
          baseline used in dev and as the SPA fallback. -->
-    <title>Manti UI — a framework-agnostic design system on Zag.js</title>
+    <title>Manti UI — a framework-agnostic design system & UI Kit on Zag.js</title>
     <meta
       name="description"
-      content="Manti UI is a framework-agnostic design system built on Zag.js behavior machines: sleek monochrome panels, semantic tones, and a token-first customization contract."
+      content="Manti UI is a framework-agnostic design system and UI Kit built on Zag.js behavior machines: sleek monochrome panels, semantic tones, and a token-first customization contract."
     />
     <link rel="canonical" href="https://manti.design" />
     <meta name="robots" content="index, follow" />
@@ -25,11 +25,11 @@
     <meta property="og:site_name" content="Manti UI" />
     <meta
       property="og:title"
-      content="Manti UI — a framework-agnostic design system on Zag.js"
+      content="Manti UI — a framework-agnostic design system & UI Kit on Zag.js"
     />
     <meta
       property="og:description"
-      content="Manti UI is a framework-agnostic design system built on Zag.js behavior machines: sleek monochrome panels, semantic tones, and a token-first customization contract."
+      content="Manti UI is a framework-agnostic design system and UI Kit built on Zag.js behavior machines: sleek monochrome panels, semantic tones, and a token-first customization contract."
     />
     <meta property="og:url" content="https://manti.design" />
     <meta property="og:image" content="https://manti.design/og-cover.png" />
@@ -39,11 +39,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="Manti UI — a framework-agnostic design system on Zag.js"
+      content="Manti UI — a framework-agnostic design system & UI Kit on Zag.js"
     />
     <meta
       name="twitter:description"
-      content="Manti UI is a framework-agnostic design system built on Zag.js behavior machines: sleek monochrome panels, semantic tones, and a token-first customization contract."
+      content="Manti UI is a framework-agnostic design system and UI Kit built on Zag.js behavior machines: sleek monochrome panels, semantic tones, and a token-first customization contract."
     />
     <meta name="twitter:image" content="https://manti.design/og-cover.png" />
     <!-- seo:end -->

--- a/packages/docs/src/content/changelog/index.mdx
+++ b/packages/docs/src/content/changelog/index.mdx
@@ -1,0 +1,14 @@
+---
+title: Changelog
+slug: /changelog
+group: Changelog
+order: 0
+description: Release notes and changelog for every version of Manti UI.
+---
+
+# Changelog
+
+Release notes for every version of Manti UI, newest first. Pick a release to read
+its full notes.
+
+<ReleasesList />

--- a/packages/docs/src/content/changelog/v0-1-0.mdx
+++ b/packages/docs/src/content/changelog/v0-1-0.mdx
@@ -1,0 +1,36 @@
+---
+title: v0.1.0
+slug: /changelog/v0.1.0
+group: Changelog
+order: 2
+date: '2026-06-23'
+description: The first public release of Manti UI.
+---
+
+# v0.1.0
+
+_Released 2026-06-23._
+
+The first public release of Manti UI — a framework-agnostic design system built on
+[Zag.js](https://zagjs.com) behavior machines.
+
+## Highlights
+
+- **Framework-agnostic foundation.** Behavior lives in Zag.js machines; tokens and
+  CSS are framework-free. A React renderer ships today, with Vue, Svelte and Solid
+  able to reuse the same foundations.
+- **Three-tier design tokens.** Primitive ramps → semantic roles & tones →
+  per-component tokens, themeable entirely from CSS variables (and bound to
+  Tailwind v4).
+- **A full React component library**, with keyboard support, focus management and
+  screen-reader semantics owned by the machines.
+- **This documentation site**, built end-to-end with Manti UI itself.
+
+## Install
+
+```bash
+npm install @manti-ui/react @manti-ui/styles
+```
+
+See [Getting Started](/getting-started) to render your first component, or browse
+the [Components](/components).

--- a/packages/docs/src/content/changelog/v0-1-1.mdx
+++ b/packages/docs/src/content/changelog/v0-1-1.mdx
@@ -1,0 +1,41 @@
+---
+title: v0.1.1
+slug: /changelog/v0.1.1
+group: Changelog
+order: 1
+date: '2026-06-25'
+description: Panel token rename, scrollable Combobox & Select listboxes, a Carousel slide-gap token, overlay fixes, and full docs SEO.
+---
+
+# v0.1.1
+
+_Released 2026-06-25._
+
+## Breaking changes
+
+- **Frosted-panel tokens renamed** from `--manti-glass-*` to `--manti-panel-*`
+  (e.g. `--manti-glass-tint` → `--manti-panel-tint`, `--manti-glass-border` →
+  `--manti-panel-border`). Update any custom CSS that referenced the old names.
+
+## Added
+
+- **Carousel** exposes a `slide-gap` component token
+  (`--manti-carousel-slide-gap`) for the space between slides.
+
+## Changed
+
+- **Combobox** and **Select** now scroll their listbox inside a Manti
+  `ScrollArea`, so long option lists stay tidy.
+
+## Fixed
+
+- **Overlay panels** — floating panels, popovers and other portaled surfaces are
+  now opaque enough to keep the UI beneath them hidden and legible.
+- **FileUpload** squares its delete trigger and renders each file's size.
+
+## Docs
+
+- Per-route **SEO**: titles, descriptions, canonical URLs, Open Graph / Twitter
+  cards, a sitemap, and robots.txt.
+- Docs and **Storybook now ship from a single Netlify deploy** — Storybook lives
+  at [`/storybook`](/storybook/).

--- a/packages/docs/src/content/components/accordion.mdx
+++ b/packages/docs/src/content/components/accordion.mdx
@@ -1,7 +1,7 @@
 ---
 title: Accordion
 slug: /components/accordion
-group: Components
+group: Data Display
 order: 11
 description: A stack of disclosures backed by the Zag.js accordion machine.
 ---

--- a/packages/docs/src/content/components/alert.mdx
+++ b/packages/docs/src/content/components/alert.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alert
 slug: /components/alert
-group: Components
+group: Feedback
 order: 15
 description: An inline, tonal message with a title, description, and optional dismiss action.
 ---

--- a/packages/docs/src/content/components/avatar.mdx
+++ b/packages/docs/src/content/components/avatar.mdx
@@ -1,7 +1,7 @@
 ---
 title: Avatar
 slug: /components/avatar
-group: Components
+group: Data Display
 order: 14
 description: An avatar with graceful image-load fallback, backed by the Zag.js avatar machine.
 ---

--- a/packages/docs/src/content/components/badge.mdx
+++ b/packages/docs/src/content/components/badge.mdx
@@ -1,7 +1,7 @@
 ---
 title: Badge
 slug: /components/badge
-group: Components
+group: Data Display
 order: 14
 description: A compact status or label chip across three variants and every tone.
 ---

--- a/packages/docs/src/content/components/button.mdx
+++ b/packages/docs/src/content/components/button.mdx
@@ -1,7 +1,7 @@
 ---
 title: Button
 slug: /components/button
-group: Components
+group: Buttons & Actions
 order: 11
 description: The workhorse action — four variants across every tone, three sizes.
 ---

--- a/packages/docs/src/content/components/card.mdx
+++ b/packages/docs/src/content/components/card.mdx
@@ -1,7 +1,7 @@
 ---
 title: Card
 slug: /components/card
-group: Components
+group: Data Display
 order: 13
 description: The signature pillowy surface — composed from header, body, and footer parts.
 ---

--- a/packages/docs/src/content/components/carousel.mdx
+++ b/packages/docs/src/content/components/carousel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Carousel
 slug: /components/carousel
-group: Components
+group: Data Display
 order: 18
 description: A slide carousel backed by the Zag.js carousel machine.
 ---

--- a/packages/docs/src/content/components/checkbox.mdx
+++ b/packages/docs/src/content/components/checkbox.mdx
@@ -1,7 +1,7 @@
 ---
 title: Checkbox
 slug: /components/checkbox
-group: Components
+group: Inputs
 order: 19
 description: A soft square control with a smoothly drawn check, backed by the Zag.js checkbox machine.
 ---

--- a/packages/docs/src/content/components/clipboard.mdx
+++ b/packages/docs/src/content/components/clipboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Clipboard
 slug: /components/clipboard
-group: Components
+group: Buttons & Actions
 order: 20
 description: A copy-to-clipboard field backed by the Zag.js clipboard machine.
 ---

--- a/packages/docs/src/content/components/collapsible.mdx
+++ b/packages/docs/src/content/components/collapsible.mdx
@@ -1,7 +1,7 @@
 ---
 title: Collapsible
 slug: /components/collapsible
-group: Components
+group: Data Display
 order: 21
 description: A single open/close disclosure backed by the Zag.js collapsible machine.
 ---

--- a/packages/docs/src/content/components/color-picker.mdx
+++ b/packages/docs/src/content/components/color-picker.mdx
@@ -1,7 +1,7 @@
 ---
 title: ColorPicker
 slug: /components/color-picker
-group: Components
+group: Inputs
 order: 22
 description: A color picker with a saturation area, hue, and alpha, backed by the Zag.js color-picker machine.
 ---

--- a/packages/docs/src/content/components/combobox.mdx
+++ b/packages/docs/src/content/components/combobox.mdx
@@ -1,7 +1,7 @@
 ---
 title: Combobox
 slug: /components/combobox
-group: Components
+group: Inputs
 order: 23
 description: A typeahead select backed by the Zag.js combobox machine, filtered client-side.
 ---

--- a/packages/docs/src/content/components/context-menu.mdx
+++ b/packages/docs/src/content/components/context-menu.mdx
@@ -1,7 +1,7 @@
 ---
 title: ContextMenu
 slug: /components/context-menu
-group: Components
+group: Navigation
 order: 24
 description: A right-click context menu backed by the Zag.js menu machine, opened at the pointer.
 ---

--- a/packages/docs/src/content/components/data-table.mdx
+++ b/packages/docs/src/content/components/data-table.mdx
@@ -1,0 +1,57 @@
+---
+title: DataTable
+slug: /components/data-table
+group: Data Display
+order: 62
+badge: New
+description: A data grid backed by the framework-agnostic TanStack table-core machine.
+---
+
+# DataTable
+
+A data grid backed by the framework-agnostic TanStack `table-core` machine. The
+machine owns sorting and the row models; the Manti adapter renders the semantic
+`<table>` anatomy and styling. Pass `columns` and `data`, then opt into sorting,
+sticky headers, zebra striping, hover, and density.
+
+<Demo name="data-table/basic" />
+
+## Columns
+
+Columns are TanStack [`ColumnDef`](https://tanstack.com/table/latest/docs/guide/column-defs)
+objects, re-exported as `DataTableColumn<TData>` so you never import from
+`@tanstack/*` directly. Use `accessorKey` for plain values, `cell` to render
+custom content, and `meta.align` (`'start' | 'center' | 'end'`) to align a
+column's header and cells together.
+
+## Sorting
+
+Set `sortable` to make headers toggle sort order. The header becomes a button
+with an `aria-sort` state and a direction arrow; sorting runs through
+`table-core`'s sorted row model.
+
+<Demo name="data-table/sortable" />
+
+## Filtering, pagination & selection
+
+Opt into more of `table-core`'s machine with `filterable` (a global search box),
+`paginated` + `pageSize` (client pagination), and `selectable` (a leading
+checkbox column). These compose Manti's own TextField, Pagination, and Checkbox,
+and `onSelectionChange` reports the selected rows. They combine freely:
+
+<Demo name="data-table/full" />
+
+## Props
+
+<PropsTable component="data-table" />
+
+## Anatomy
+
+Target these public selectors to customize the data table. Class names and the
+DOM between parts are private.
+
+<Anatomy component="data-table" />
+
+## Component tokens
+
+<TokenTable component="data-table" />

--- a/packages/docs/src/content/components/date-picker.mdx
+++ b/packages/docs/src/content/components/date-picker.mdx
@@ -1,7 +1,7 @@
 ---
 title: DatePicker
 slug: /components/date-picker
-group: Components
+group: Inputs
 order: 25
 description: A calendar date picker backed by the Zag.js date-picker machine.
 ---

--- a/packages/docs/src/content/components/dialog.mdx
+++ b/packages/docs/src/content/components/dialog.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dialog
 slug: /components/dialog
-group: Components
+group: Overlays
 order: 17
 description: A modal translucent panel backed by the Zag.js dialog machine.
 ---

--- a/packages/docs/src/content/components/drawer.mdx
+++ b/packages/docs/src/content/components/drawer.mdx
@@ -1,7 +1,7 @@
 ---
 title: Drawer
 slug: /components/drawer
-group: Components
+group: Overlays
 order: 26
 description: An edge-anchored panel that slides in, backed by the Zag.js dialog machine.
 ---

--- a/packages/docs/src/content/components/editable.mdx
+++ b/packages/docs/src/content/components/editable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Editable
 slug: /components/editable
-group: Components
+group: Inputs
 order: 27
 description: An inline text field that toggles between preview and edit, backed by the Zag.js editable machine.
 ---

--- a/packages/docs/src/content/components/file-upload.mdx
+++ b/packages/docs/src/content/components/file-upload.mdx
@@ -1,7 +1,7 @@
 ---
 title: FileUpload
 slug: /components/file-upload
-group: Components
+group: Inputs
 order: 28
 description: A file dropzone with previews backed by the Zag.js file-upload machine.
 ---

--- a/packages/docs/src/content/components/floating-panel.mdx
+++ b/packages/docs/src/content/components/floating-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: FloatingPanel
 slug: /components/floating-panel
-group: Components
+group: Overlays
 order: 29
 description: A draggable, resizable floating panel backed by the Zag.js floating-panel machine.
 ---

--- a/packages/docs/src/content/components/hover-card.mdx
+++ b/packages/docs/src/content/components/hover-card.mdx
@@ -1,7 +1,7 @@
 ---
 title: HoverCard
 slug: /components/hover-card
-group: Components
+group: Overlays
 order: 30
 description: A rich floating preview revealed on hover or focus.
 ---

--- a/packages/docs/src/content/components/listbox.mdx
+++ b/packages/docs/src/content/components/listbox.mdx
@@ -1,7 +1,7 @@
 ---
 title: Listbox
 slug: /components/listbox
-group: Components
+group: Inputs
 order: 31
 description: A selectable list backed by the Zag.js listbox machine.
 ---

--- a/packages/docs/src/content/components/marquee.mdx
+++ b/packages/docs/src/content/components/marquee.mdx
@@ -1,7 +1,7 @@
 ---
 title: Marquee
 slug: /components/marquee
-group: Components
+group: Data Display
 order: 32
 description: A continuously scrolling strip of content.
 ---

--- a/packages/docs/src/content/components/menu.mdx
+++ b/packages/docs/src/content/components/menu.mdx
@@ -1,7 +1,7 @@
 ---
 title: Menu
 slug: /components/menu
-group: Components
+group: Navigation
 order: 33
 description: A dropdown command menu backed by the Zag.js menu machine.
 ---

--- a/packages/docs/src/content/components/navigation-menu.mdx
+++ b/packages/docs/src/content/components/navigation-menu.mdx
@@ -1,7 +1,7 @@
 ---
 title: NavigationMenu
 slug: /components/navigation-menu
-group: Components
+group: Navigation
 order: 34
 description: Site navigation with rich dropdowns backed by the Zag.js navigation-menu machine.
 ---
@@ -12,7 +12,7 @@ A site navigation bar with rich dropdowns backed by the Zag.js navigation-menu
 machine. The machine owns the open/close transitions, the sliding indicator, and
 keyboard navigation.
 
-<Demo name="navigation-menu/basic" center />
+<Demo name="navigation-menu/basic" center roomy />
 
 ## Basic
 
@@ -20,7 +20,7 @@ Each top-level menu is `{ value, label, links }`, and every link is
 `{ href, label, description? }`. The machine reveals the matching `content` panel
 when its `trigger` opens.
 
-<Demo name="navigation-menu/basic" center />
+<Demo name="navigation-menu/basic" center roomy />
 
 ## Props
 

--- a/packages/docs/src/content/components/number-input.mdx
+++ b/packages/docs/src/content/components/number-input.mdx
@@ -1,7 +1,7 @@
 ---
 title: NumberInput
 slug: /components/number-input
-group: Components
+group: Inputs
 order: 35
 description: A numeric stepper backed by the Zag.js number-input machine.
 ---

--- a/packages/docs/src/content/components/pagination.mdx
+++ b/packages/docs/src/content/components/pagination.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pagination
 slug: /components/pagination
-group: Components
+group: Navigation
 order: 36
 description: A page navigator backed by the Zag.js pagination machine.
 ---

--- a/packages/docs/src/content/components/password-input.mdx
+++ b/packages/docs/src/content/components/password-input.mdx
@@ -1,7 +1,7 @@
 ---
 title: PasswordInput
 slug: /components/password-input
-group: Components
+group: Inputs
 order: 50
 description: A password field with a show/hide toggle and a Caps Lock warning.
 ---

--- a/packages/docs/src/content/components/pin-input.mdx
+++ b/packages/docs/src/content/components/pin-input.mdx
@@ -1,7 +1,7 @@
 ---
 title: PinInput
 slug: /components/pin-input
-group: Components
+group: Inputs
 order: 37
 description: A segmented code entry backed by the Zag.js pin-input machine.
 ---

--- a/packages/docs/src/content/components/popover.mdx
+++ b/packages/docs/src/content/components/popover.mdx
@@ -1,7 +1,7 @@
 ---
 title: Popover
 slug: /components/popover
-group: Components
+group: Overlays
 order: 38
 description: A floating translucent panel anchored to a trigger, backed by the Zag.js popover machine.
 ---

--- a/packages/docs/src/content/components/progress.mdx
+++ b/packages/docs/src/content/components/progress.mdx
@@ -1,7 +1,7 @@
 ---
 title: Progress
 slug: /components/progress
-group: Components
+group: Feedback
 order: 39
 description: A determinate or indeterminate progress indicator backed by the Zag.js progress machine.
 ---

--- a/packages/docs/src/content/components/qr-code.mdx
+++ b/packages/docs/src/content/components/qr-code.mdx
@@ -1,7 +1,7 @@
 ---
 title: QrCode
 slug: /components/qr-code
-group: Components
+group: Data Display
 order: 40
 description: A QR code backed by the Zag.js qr-code machine.
 ---

--- a/packages/docs/src/content/components/radio-group.mdx
+++ b/packages/docs/src/content/components/radio-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: RadioGroup
 slug: /components/radio-group
-group: Components
+group: Inputs
 order: 41
 description: A set of mutually exclusive options backed by the Zag.js radio-group machine.
 ---

--- a/packages/docs/src/content/components/rating-group.mdx
+++ b/packages/docs/src/content/components/rating-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: RatingGroup
 slug: /components/rating-group
-group: Components
+group: Inputs
 order: 42
 description: A star rating backed by the Zag.js rating-group machine.
 ---

--- a/packages/docs/src/content/components/scroll-area.mdx
+++ b/packages/docs/src/content/components/scroll-area.mdx
@@ -1,7 +1,7 @@
 ---
 title: ScrollArea
 slug: /components/scroll-area
-group: Components
+group: Layout
 order: 51
 description: A scrollable viewport with sleek, theme-aware scrollbars.
 ---

--- a/packages/docs/src/content/components/segmented-control.mdx
+++ b/packages/docs/src/content/components/segmented-control.mdx
@@ -1,7 +1,7 @@
 ---
 title: SegmentedControl
 slug: /components/segmented-control
-group: Components
+group: Inputs
 order: 59
 description: A single-select control with a pill that slides to the active segment.
 ---

--- a/packages/docs/src/content/components/select.mdx
+++ b/packages/docs/src/content/components/select.mdx
@@ -1,7 +1,7 @@
 ---
 title: Select
 slug: /components/select
-group: Components
+group: Inputs
 order: 43
 description: A single or multi select backed by the Zag.js select machine.
 ---

--- a/packages/docs/src/content/components/signature-pad.mdx
+++ b/packages/docs/src/content/components/signature-pad.mdx
@@ -1,7 +1,7 @@
 ---
 title: SignaturePad
 slug: /components/signature-pad
-group: Components
+group: Inputs
 order: 44
 description: A drawable signature surface backed by the Zag.js signature-pad machine.
 ---

--- a/packages/docs/src/content/components/slider.mdx
+++ b/packages/docs/src/content/components/slider.mdx
@@ -1,7 +1,7 @@
 ---
 title: Slider
 slug: /components/slider
-group: Components
+group: Inputs
 order: 45
 description: A draggable value selector backed by the Zag.js slider machine.
 ---

--- a/packages/docs/src/content/components/spinner.mdx
+++ b/packages/docs/src/content/components/spinner.mdx
@@ -1,7 +1,7 @@
 ---
 title: Spinner
 slug: /components/spinner
-group: Components
+group: Feedback
 order: 46
 description: A calm, continuous loading indicator.
 ---

--- a/packages/docs/src/content/components/splitter.mdx
+++ b/packages/docs/src/content/components/splitter.mdx
@@ -1,7 +1,7 @@
 ---
 title: Splitter
 slug: /components/splitter
-group: Components
+group: Layout
 order: 47
 description: A resizable split layout backed by the Zag.js splitter machine.
 ---

--- a/packages/docs/src/content/components/steps.mdx
+++ b/packages/docs/src/content/components/steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: Steps
 slug: /components/steps
-group: Components
+group: Navigation
 order: 48
 description: A step-by-step flow backed by the Zag.js steps machine.
 ---

--- a/packages/docs/src/content/components/swipe.mdx
+++ b/packages/docs/src/content/components/swipe.mdx
@@ -1,7 +1,7 @@
 ---
 title: Swipe
 slug: /components/swipe
-group: Components
+group: Layout
 order: 49
 description: A gesture surface that makes any content swipeable on either axis.
 ---

--- a/packages/docs/src/content/components/switch.mdx
+++ b/packages/docs/src/content/components/switch.mdx
@@ -1,7 +1,7 @@
 ---
 title: Switch
 slug: /components/switch
-group: Components
+group: Inputs
 order: 12
 description: A smooth on/off control backed by a Zag.js machine, with sizes and tones.
 ---

--- a/packages/docs/src/content/components/tabs.mdx
+++ b/packages/docs/src/content/components/tabs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tabs
 slug: /components/tabs
-group: Components
+group: Navigation
 order: 16
 description: Tabbed navigation backed by the Zag.js tabs machine, in three styles.
 ---

--- a/packages/docs/src/content/components/tags-input.mdx
+++ b/packages/docs/src/content/components/tags-input.mdx
@@ -1,7 +1,7 @@
 ---
 title: TagsInput
 slug: /components/tags-input
-group: Components
+group: Inputs
 order: 52
 description: A multi-value entry field backed by the Zag.js tags-input machine.
 ---

--- a/packages/docs/src/content/components/text-field.mdx
+++ b/packages/docs/src/content/components/text-field.mdx
@@ -1,7 +1,7 @@
 ---
 title: TextField
 slug: /components/text-field
-group: Components
+group: Inputs
 order: 53
 description: A labeled text input with hint, error, and optional adornments.
 ---

--- a/packages/docs/src/content/components/time-picker.mdx
+++ b/packages/docs/src/content/components/time-picker.mdx
@@ -1,7 +1,7 @@
 ---
 title: TimePicker
 slug: /components/time-picker
-group: Components
+group: Inputs
 order: 54
 description: A time picker backed by the Zag.js time-picker machine.
 ---

--- a/packages/docs/src/content/components/timer.mdx
+++ b/packages/docs/src/content/components/timer.mdx
@@ -1,7 +1,7 @@
 ---
 title: Timer
 slug: /components/timer
-group: Components
+group: Feedback
 order: 55
 description: A count-up / count-down timer backed by the Zag.js timer machine.
 ---

--- a/packages/docs/src/content/components/toast.mdx
+++ b/packages/docs/src/content/components/toast.mdx
@@ -1,7 +1,7 @@
 ---
 title: Toast
 slug: /components/toast
-group: Components
+group: Feedback
 order: 56
 description: Translucent, tone-colored notifications backed by the Zag.js toast machine.
 ---

--- a/packages/docs/src/content/components/toggle-group.mdx
+++ b/packages/docs/src/content/components/toggle-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: ToggleGroup
 slug: /components/toggle-group
-group: Components
+group: Buttons & Actions
 order: 58
 description: A set of toggle buttons backed by the Zag.js toggle-group machine.
 ---

--- a/packages/docs/src/content/components/toggle.mdx
+++ b/packages/docs/src/content/components/toggle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Toggle
 slug: /components/toggle
-group: Components
+group: Buttons & Actions
 order: 57
 description: A pressable two-state button backed by the Zag.js toggle machine.
 ---

--- a/packages/docs/src/content/components/tooltip.mdx
+++ b/packages/docs/src/content/components/tooltip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tooltip
 slug: /components/tooltip
-group: Components
+group: Overlays
 order: 18
 description: A floating label backed by the Zag.js tooltip machine.
 ---

--- a/packages/docs/src/content/components/tour.mdx
+++ b/packages/docs/src/content/components/tour.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tour
 slug: /components/tour
-group: Components
+group: Overlays
 order: 60
 description: A guided product tour backed by the Zag.js tour machine.
 ---

--- a/packages/docs/src/content/components/tree-view.mdx
+++ b/packages/docs/src/content/components/tree-view.mdx
@@ -1,7 +1,7 @@
 ---
 title: TreeView
 slug: /components/tree-view
-group: Components
+group: Navigation
 order: 61
 description: A nested, keyboard-navigable tree backed by the Zag.js tree-view machine.
 ---

--- a/packages/docs/src/data/componentMeta.ts
+++ b/packages/docs/src/data/componentMeta.ts
@@ -440,6 +440,7 @@ export const componentCatalog: CatalogEntry[] = [
   entry('ColorPicker', 'color-picker', 'Area + channel color selection.'),
   entry('Combobox', 'combobox', 'Autocomplete text + listbox.'),
   entry('ContextMenu', 'context-menu', 'Right-click menu surface.'),
+  entry('DataTable', 'data-table', 'Sortable data grid via TanStack table.'),
   entry('DatePicker', 'date-picker', 'Calendar date selection.'),
   entry('Dialog', 'dialog', 'Modal translucent panel.'),
   entry('Drawer', 'drawer', 'Edge-anchored sliding panel.'),

--- a/packages/docs/src/data/components/data-table.ts
+++ b/packages/docs/src/data/components/data-table.ts
@@ -1,0 +1,146 @@
+import type { ComponentMeta } from '../component-meta-types';
+
+export const meta: ComponentMeta = {
+  scope: 'data-table',
+  props: [
+    {
+      name: 'columns',
+      type: 'DataTableColumn<TData>[]',
+      description:
+        'Column definitions (TanStack `ColumnDef`). Set `meta.align` to align a column.',
+    },
+    {
+      name: 'data',
+      type: 'TData[]',
+      description: 'The rows to render.',
+    },
+    {
+      name: 'title',
+      type: 'ReactNode',
+      description:
+        'A heading shown at the start of the toolbar; also names the table.',
+    },
+    {
+      name: 'sortable',
+      type: 'boolean',
+      default: 'false',
+      description: 'Enable click-to-sort headers (one column at a time).',
+    },
+    {
+      name: 'filterable',
+      type: 'boolean',
+      default: 'false',
+      description: 'Add a global search box that filters across every column.',
+    },
+    {
+      name: 'filterPlaceholder',
+      type: 'string',
+      default: `'Search…'`,
+      description: 'Placeholder for the search box.',
+    },
+    {
+      name: 'paginated',
+      type: 'boolean',
+      default: 'false',
+      description: 'Paginate client-side, with a Pagination control in the footer.',
+    },
+    {
+      name: 'pageSize',
+      type: 'number',
+      default: '10',
+      description: 'Rows per page when `paginated`.',
+    },
+    {
+      name: 'selectable',
+      type: 'boolean',
+      default: 'false',
+      description: 'Add a leading checkbox column for row selection.',
+    },
+    {
+      name: 'onSelectionChange',
+      type: '(rows: TData[]) => void',
+      description: 'Called with the selected rows whenever the selection changes.',
+    },
+    {
+      name: 'size',
+      type: `'sm' | 'md' | 'lg'`,
+      default: `'md'`,
+      description: 'Row density.',
+    },
+    {
+      name: 'stickyHeader',
+      type: 'boolean',
+      default: 'false',
+      description: 'Pin the header while the body scrolls (needs a bounded height).',
+    },
+    {
+      name: 'zebra',
+      type: 'boolean',
+      default: 'false',
+      description: 'Tint alternating rows.',
+    },
+    {
+      name: 'interactive',
+      type: 'boolean',
+      default: 'false',
+      description: 'Highlight rows on hover.',
+    },
+    {
+      name: 'caption',
+      type: 'ReactNode',
+      description: 'Optional caption rendered above the grid.',
+    },
+    {
+      name: 'emptyContent',
+      type: 'ReactNode',
+      default: `'No data'`,
+      description: 'Shown in place of rows when `data` is empty.',
+    },
+    {
+      name: 'getRowId',
+      type: '(row: TData, index: number) => string',
+      description: 'Derive a stable row id (defaults to the row index).',
+    },
+  ],
+  anatomy: [
+    { part: 'root', description: 'The panel framing the toolbar, grid, and footer.' },
+    {
+      part: 'toolbar',
+      description: 'The top bar holding the title and search box.',
+    },
+    { part: 'title', description: 'The toolbar heading (when `title` is set).' },
+    { part: 'search', description: 'The search field wrapper.' },
+    { part: 'viewport', description: 'The scrollable region wrapping the table.' },
+    { part: 'table', description: 'The <table> element.' },
+    { part: 'caption', description: 'The <caption>, when provided.' },
+    { part: 'header', description: 'The <thead>.' },
+    { part: 'header-row', description: 'A header <tr>.' },
+    {
+      part: 'header-cell',
+      description: 'A header <th>; carries `aria-sort` and `data-align`.',
+    },
+    {
+      part: 'sort-trigger',
+      description: 'The header button toggling sort (sortable columns).',
+    },
+    {
+      part: 'sort-indicator',
+      description: 'The arrow reflecting sort direction.',
+    },
+    { part: 'body', description: 'The <tbody>.' },
+    {
+      part: 'row',
+      description: 'A body <tr>; carries `data-selected` when selected.',
+    },
+    { part: 'cell', description: 'A body <td>; carries `data-align`.' },
+    { part: 'empty', description: 'The cell shown when there are no rows.' },
+    {
+      part: 'footer',
+      description: 'The bottom bar holding the selection summary and pager.',
+    },
+    {
+      part: 'selection-summary',
+      description: 'The “N selected” count (when selectable).',
+    },
+  ],
+};

--- a/packages/docs/src/data/navigation.ts
+++ b/packages/docs/src/data/navigation.ts
@@ -3,6 +3,8 @@ import { pages } from '../pages';
 export interface NavItem {
   slug: string;
   title: string;
+  /** Small tag shown after the title, e.g. `New`. */
+  badge?: string;
 }
 
 export interface NavGroup {
@@ -10,26 +12,46 @@ export interface NavGroup {
   items: NavItem[];
 }
 
+// Components are split into these categories, each its own sidebar section. The
+// names mirror the `group` frontmatter of every component page under content/.
+const COMPONENT_CATEGORIES = [
+  'Inputs',
+  'Buttons & Actions',
+  'Navigation',
+  'Overlays',
+  'Feedback',
+  'Data Display',
+  'Layout',
+] as const;
+
 /** Sidebar group order. Pages with a group outside this list are not listed. */
 const GROUP_ORDER = [
   'Getting Started',
   'Foundations',
   'Guides',
+  // The `/components` overview sits alone in its "Components" group, above the
+  // categorized component sections.
   'Components',
+  ...COMPONENT_CATEGORIES,
   'Reference',
+  'Changelog',
 ] as const;
+
+const COMPONENT_CATEGORY_SET = new Set<string>(COMPONENT_CATEGORIES);
 
 export const navGroups: NavGroup[] = GROUP_ORDER.map((label) => {
   let items: NavItem[] = pages
     .filter((page) => page.group === label)
-    .map((page) => ({ slug: page.slug, title: page.title }));
-  // The Components group is alphabetical, with the overview pinned to the top.
-  if (label === 'Components') {
-    items = [...items].sort((a, b) => {
-      if (a.slug === '/components') return -1;
-      if (b.slug === '/components') return 1;
-      return a.title.localeCompare(b.title);
-    });
+    .map((page) => ({
+      slug: page.slug,
+      // The overview page is titled "Components"; label its lone sidebar link
+      // "Overview" so it doesn't echo the section heading above it.
+      title: page.slug === '/components' ? 'Overview' : page.title,
+      badge: page.badge,
+    }));
+  // Component categories list their items alphabetically rather than by `order`.
+  if (COMPONENT_CATEGORY_SET.has(label)) {
+    items = [...items].sort((a, b) => a.title.localeCompare(b.title));
   }
   return { label, items };
 }).filter((group) => group.items.length > 0);
@@ -43,7 +65,13 @@ export const primaryNav: NavItem[] = [
   { slug: '/foundations/design-signature', title: 'Foundations' },
   { slug: '/components', title: 'Components' },
   { slug: '/guides/plain-css', title: 'Guides' },
+  { slug: '/changelog', title: 'Changelog' },
 ];
+
+/** Published Manti version (injected at build time — see vite.config.ts). */
+export const MANTI_VERSION = __MANTI_VERSION__;
+/** Release-notes page for the current version (target of the header badge). */
+export const LATEST_CHANGELOG_SLUG = `/changelog/v${MANTI_VERSION}`;
 
 export const GITHUB_URL = 'https://github.com/manti-ui/ui';
 // Storybook ships in the same Netlify deploy, served at the /storybook subpath.

--- a/packages/docs/src/demos/data-table/basic.tsx
+++ b/packages/docs/src/demos/data-table/basic.tsx
@@ -1,0 +1,24 @@
+import { DataTable } from '@manti-ui/react';
+import type { DataTableColumn } from '@manti-ui/react';
+
+interface Member {
+  name: string;
+  role: string;
+  location: string;
+}
+
+const data: Member[] = [
+  { name: 'Ada Lovelace', role: 'Engineer', location: 'London' },
+  { name: 'Alan Turing', role: 'Researcher', location: 'Manchester' },
+  { name: 'Grace Hopper', role: 'Architect', location: 'New York' },
+];
+
+const columns: DataTableColumn<Member>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'role', header: 'Role' },
+  { accessorKey: 'location', header: 'Location' },
+];
+
+export default function DataTableBasic() {
+  return <DataTable columns={columns} data={data} />;
+}

--- a/packages/docs/src/demos/data-table/full.tsx
+++ b/packages/docs/src/demos/data-table/full.tsx
@@ -1,0 +1,76 @@
+import { Badge, DataTable } from '@manti-ui/react';
+import type { DataTableColumn } from '@manti-ui/react';
+
+interface Invoice {
+  id: string;
+  customer: string;
+  status: 'paid' | 'pending' | 'overdue';
+  amount: number;
+}
+
+const data: Invoice[] = [
+  { id: 'INV-001', customer: 'Acme Corp', status: 'paid', amount: 1200 },
+  { id: 'INV-002', customer: 'Globex', status: 'pending', amount: 450.5 },
+  { id: 'INV-003', customer: 'Initech', status: 'overdue', amount: 3120 },
+  { id: 'INV-004', customer: 'Umbrella', status: 'paid', amount: 88 },
+  { id: 'INV-005', customer: 'Soylent', status: 'pending', amount: 640 },
+  { id: 'INV-006', customer: 'Hooli', status: 'paid', amount: 2750 },
+  { id: 'INV-007', customer: 'Pied Piper', status: 'overdue', amount: 410 },
+  { id: 'INV-008', customer: 'Stark Industries', status: 'paid', amount: 9800 },
+  { id: 'INV-009', customer: 'Wayne Enterprises', status: 'pending', amount: 1500 },
+  { id: 'INV-010', customer: 'Wonka', status: 'paid', amount: 320 },
+  { id: 'INV-011', customer: 'Cyberdyne', status: 'overdue', amount: 6100 },
+  { id: 'INV-012', customer: 'Tyrell Corp', status: 'paid', amount: 240 },
+];
+
+const statusTone = {
+  paid: 'success',
+  pending: 'warning',
+  overdue: 'danger',
+} as const;
+
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+const columns: DataTableColumn<Invoice>[] = [
+  { accessorKey: 'id', header: 'Invoice' },
+  { accessorKey: 'customer', header: 'Customer' },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ getValue }) => {
+      const status = getValue<Invoice['status']>();
+      return (
+        <Badge tone={statusTone[status]} variant="soft">
+          {status}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: 'amount',
+    header: 'Amount',
+    meta: { align: 'end' },
+    cell: ({ getValue }) => currency.format(getValue<number>()),
+  },
+];
+
+export default function DataTableFull() {
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      title="Invoices"
+      getRowId={(row) => row.id}
+      sortable
+      filterable
+      paginated
+      pageSize={5}
+      selectable
+      zebra
+      interactive
+    />
+  );
+}

--- a/packages/docs/src/demos/data-table/sortable.tsx
+++ b/packages/docs/src/demos/data-table/sortable.tsx
@@ -1,0 +1,54 @@
+import { Badge, DataTable } from '@manti-ui/react';
+import type { DataTableColumn } from '@manti-ui/react';
+
+interface Invoice {
+  id: string;
+  customer: string;
+  status: 'paid' | 'pending' | 'overdue';
+  amount: number;
+}
+
+const data: Invoice[] = [
+  { id: 'INV-001', customer: 'Acme Corp', status: 'paid', amount: 1200 },
+  { id: 'INV-002', customer: 'Globex', status: 'pending', amount: 450.5 },
+  { id: 'INV-003', customer: 'Initech', status: 'overdue', amount: 3120 },
+  { id: 'INV-004', customer: 'Umbrella', status: 'paid', amount: 88 },
+];
+
+const statusTone = {
+  paid: 'success',
+  pending: 'warning',
+  overdue: 'danger',
+} as const;
+
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+const columns: DataTableColumn<Invoice>[] = [
+  { accessorKey: 'id', header: 'Invoice' },
+  { accessorKey: 'customer', header: 'Customer' },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ getValue }) => {
+      const status = getValue<Invoice['status']>();
+      return (
+        <Badge tone={statusTone[status]} variant="soft">
+          {status}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: 'amount',
+    header: 'Amount',
+    meta: { align: 'end' },
+    cell: ({ getValue }) => currency.format(getValue<number>()),
+  },
+];
+
+export default function DataTableSortable() {
+  return <DataTable columns={columns} data={data} sortable zebra interactive />;
+}

--- a/packages/docs/src/doc/Demo.tsx
+++ b/packages/docs/src/doc/Demo.tsx
@@ -57,11 +57,23 @@ export interface DemoProps {
   name: string;
   /** Center the preview instead of left-aligning it. */
   center?: boolean;
+  /** Reserve vertical room and top-align the preview — for demos whose inline
+   * dropdown opens downward (e.g. NavigationMenu) and would otherwise be
+   * clipped by the canvas overflow. */
+  roomy?: boolean;
 }
 
-export function Demo({ name, center }: DemoProps) {
+export function Demo({ name, center, roomy }: DemoProps) {
   const { Component, source, html } = resolve(name);
   const [showCode, setShowCode] = useState(false);
+
+  const canvasClass = [
+    'docs-demo-canvas',
+    center && 'is-center',
+    roomy && 'is-roomy',
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   if (!Component) {
     return (
@@ -73,9 +85,7 @@ export function Demo({ name, center }: DemoProps) {
 
   return (
     <div className="docs-demo">
-      <div
-        className={center ? 'docs-demo-canvas is-center' : 'docs-demo-canvas'}
-      >
+      <div className={canvasClass}>
         <Component />
       </div>
       {source && html && (

--- a/packages/docs/src/doc/ReleasesList.tsx
+++ b/packages/docs/src/doc/ReleasesList.tsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router-dom';
+
+import { pages } from '../pages';
+
+// Release pages live in the Changelog group (excluding the /changelog overview),
+// already sorted newest-first by their `order`.
+const releases = pages.filter(
+  (page) => page.group === 'Changelog' && page.slug !== '/changelog',
+);
+
+/**
+ * The releases overview: a plain stacked list (not cards). Each row is a link to
+ * that version's notes, with a subtle hover.
+ */
+export function ReleasesList() {
+  return (
+    <div className="docs-releases">
+      {releases.map((release) => (
+        <Link key={release.slug} to={release.slug} className="docs-release">
+          <span className="docs-release-title">
+            {release.title}
+            {release.date && (
+              <span className="docs-release-date"> — {release.date}</span>
+            )}
+          </span>
+          {release.description && (
+            <span className="docs-release-summary">{release.description}</span>
+          )}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/packages/docs/src/mdx/MDXComponents.tsx
+++ b/packages/docs/src/mdx/MDXComponents.tsx
@@ -8,6 +8,7 @@ import { ComponentStatusGrid } from '../doc/ComponentStatusGrid';
 import { Demo } from '../doc/Demo';
 import { LinkButton } from '../doc/LinkButton';
 import { PropsTable } from '../doc/PropsTable';
+import { ReleasesList } from '../doc/ReleasesList';
 import { TokenTable } from '../doc/TokenTable';
 import { TypeScale, WeightScale } from '../doc/TypeScale';
 import { CodeBlock } from './CodeBlock';
@@ -60,4 +61,5 @@ export const mdxComponents = {
   TypeScale,
   WeightScale,
   ComponentStatusGrid,
+  ReleasesList,
 };

--- a/packages/docs/src/pages.ts
+++ b/packages/docs/src/pages.ts
@@ -20,6 +20,9 @@ export interface DocPage {
   group: string;
   order: number;
   description?: string;
+  date?: string;
+  /** Small sidebar tag, e.g. `New`. */
+  badge?: string;
   Component: ComponentType;
   toc: TocEntry[];
 }
@@ -31,6 +34,8 @@ export const pages: DocPage[] = Object.values(modules)
     group: mod.frontmatter.group ?? '',
     order: mod.frontmatter.order ?? 0,
     description: mod.frontmatter.description,
+    date: mod.frontmatter.date,
+    badge: mod.frontmatter.badge,
     Component: mod.default,
     toc: mod.tableOfContents ?? [],
   }))

--- a/packages/docs/src/shell/Sidebar.tsx
+++ b/packages/docs/src/shell/Sidebar.tsx
@@ -1,15 +1,50 @@
 import { NavLink } from 'react-router-dom';
-import { ScrollArea } from '@manti-ui/react';
+import { Collapsible, ScrollArea } from '@manti-ui/react';
 
 import { navGroups } from '../data/navigation';
 
-/** The grouped page list. Shared by the desktop sidebar and the mobile menu. */
+function ChevronIcon() {
+  return (
+    <svg
+      className="docs-nav-group-chevron"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+    >
+      <path
+        d="M3 4.5L6 7.5l3-3"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/**
+ * The grouped page list. Shared by the desktop sidebar and the mobile menu.
+ * Each group is a Manti Collapsible so categories can be expanded/collapsed;
+ * open by default, with the state persisting across in-app navigation (the
+ * sidebar lives in the persistent layout shell).
+ */
 export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   return (
-    <nav aria-label="Documentation">
+    <nav aria-label="Documentation" className="docs-sidebar-nav">
       {navGroups.map((group) => (
-        <div key={group.label} className="docs-nav-group">
-          <p className="docs-nav-group-label">{group.label}</p>
+        <Collapsible
+          key={group.label}
+          className="docs-nav-group"
+          defaultOpen
+          trigger={
+            <>
+              <span>{group.label}</span>
+              <ChevronIcon />
+            </>
+          }
+        >
           <ul className="docs-nav-list">
             {group.items.map((item) => (
               <li key={item.slug}>
@@ -20,11 +55,16 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
                   onClick={onNavigate}
                 >
                   {item.title}
+                  {item.badge && (
+                    <span className="docs-side-badge" data-tone="primary">
+                      {item.badge}
+                    </span>
+                  )}
                 </NavLink>
               </li>
             ))}
           </ul>
-        </div>
+        </Collapsible>
       ))}
     </nav>
   );

--- a/packages/docs/src/shell/TopNav.tsx
+++ b/packages/docs/src/shell/TopNav.tsx
@@ -1,8 +1,14 @@
 import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
-import { Button, Dialog } from '@manti-ui/react';
+import { Badge, Button, Dialog } from '@manti-ui/react';
 
-import { GITHUB_URL, STORYBOOK_URL, primaryNav } from '../data/navigation';
+import {
+  GITHUB_URL,
+  LATEST_CHANGELOG_SLUG,
+  MANTI_VERSION,
+  STORYBOOK_URL,
+  primaryNav,
+} from '../data/navigation';
 import { useSearch } from '../search/SearchProvider';
 import { useTheme } from '../theme/useTheme';
 import { MenuIcon, MoonIcon, SearchIcon, SunIcon } from './icons';
@@ -18,6 +24,16 @@ export function TopNav() {
       <Link to="/" className="docs-brand" aria-label="Manti UI home">
         <img src="/manti-white.svg" alt="" />
         <span>Manti UI</span>
+      </Link>
+
+      <Link
+        to={LATEST_CHANGELOG_SLUG}
+        className="docs-version"
+        aria-label={`Version ${MANTI_VERSION} — what's new`}
+      >
+        <Badge tone="primary" variant="soft" size="sm">
+          v{MANTI_VERSION}
+        </Badge>
       </Link>
 
       <nav className="docs-nav-primary" aria-label="Primary">

--- a/packages/docs/src/styles/docs.css
+++ b/packages/docs/src/styles/docs.css
@@ -83,6 +83,52 @@
     height: var(--manti-space-10);
   }
 
+  /* Version badge link next to the wordmark. */
+  .docs-version {
+    display: inline-flex;
+    text-decoration: none;
+    transition: opacity var(--manti-duration-fast) var(--manti-ease-smooth);
+  }
+  .docs-version:hover {
+    opacity: 0.78;
+  }
+
+  /* ---- Releases list (Changelog overview) — plain stacked rows, not cards ---- */
+  .docs-releases {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: var(--manti-space-6);
+    border-top: 1px solid var(--manti-border);
+  }
+  .docs-release {
+    display: block;
+    padding: var(--manti-space-4) var(--manti-space-3);
+    border-bottom: 1px solid var(--manti-border);
+    text-decoration: none;
+    color: inherit;
+    transition: background var(--manti-duration-fast) var(--manti-ease-smooth);
+  }
+  .docs-release:hover {
+    background: var(--manti-surface);
+  }
+  .docs-release-title {
+    display: block;
+    font-size: var(--manti-text-lg);
+    font-weight: var(--manti-weight-semibold);
+    color: var(--manti-text);
+  }
+  .docs-release-date {
+    font-size: var(--manti-text-sm);
+    font-weight: var(--manti-weight-regular);
+    color: var(--manti-text-subtle);
+  }
+  .docs-release-summary {
+    display: block;
+    margin-top: var(--manti-space-1);
+    color: var(--manti-text-muted);
+    font-size: var(--manti-text-sm);
+  }
+
   .docs-nav-primary {
     display: flex;
     align-items: center;
@@ -163,18 +209,43 @@
     padding-block: var(--manti-space-8);
   }
 
-  /* ---- Sidebar nav ---- */
+  /* ---- Sidebar nav (collapsible category groups) ---- */
   .docs-nav-group + .docs-nav-group {
-    margin-top: var(--manti-space-6);
+    margin-top: var(--manti-space-3);
   }
-  .docs-nav-group-label {
-    margin: 0 0 var(--manti-space-2);
-    padding-inline: var(--manti-space-3);
+  /* Restyle the Manti Collapsible trigger as a minimal, full-width category
+     header (the panel-button default is replaced via the public anatomy). */
+  .docs-sidebar-nav [data-scope='collapsible'][data-part='trigger'] {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    margin-bottom: var(--manti-space-1);
+    padding: var(--manti-space-1) var(--manti-space-3);
+    background: none;
+    border: none;
+    border-radius: var(--manti-radius-md);
+    box-shadow: none;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    color: var(--manti-text-subtle);
     font-size: var(--manti-text-xs);
     font-weight: var(--manti-weight-semibold);
     letter-spacing: 0.06em;
     text-transform: uppercase;
+  }
+  .docs-sidebar-nav [data-scope='collapsible'][data-part='trigger']:hover {
+    background: none;
+    color: var(--manti-text-muted);
+  }
+  .docs-nav-group-chevron {
+    flex: none;
     color: var(--manti-text-subtle);
+    transition: transform var(--manti-duration-base) var(--manti-ease-smooth);
+  }
+  .docs-sidebar-nav
+    [data-scope='collapsible'][data-part='trigger'][data-state='open']
+    .docs-nav-group-chevron {
+    transform: rotate(180deg);
   }
   .docs-nav-list {
     list-style: none;
@@ -185,7 +256,9 @@
     gap: 1px;
   }
   .docs-side-link {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: var(--manti-space-2);
     padding: var(--manti-space-1) var(--manti-space-3);
     border-radius: var(--manti-radius-md);
     color: var(--manti-text-muted);
@@ -203,6 +276,18 @@
     color: var(--manti-text);
     background: var(--manti-surface);
     font-weight: var(--manti-weight-medium);
+  }
+  /* Small "New"/"Beta" tag, pushed to the trailing edge of the link. */
+  .docs-side-badge {
+    margin-inline-start: auto;
+    padding: 0 var(--manti-space-2);
+    border-radius: var(--manti-radius-full);
+    background: var(--tone-soft-bg);
+    color: var(--tone-soft-text);
+    font-size: var(--manti-text-xs);
+    font-weight: var(--manti-weight-semibold);
+    letter-spacing: 0.02em;
+    line-height: var(--manti-leading-relaxed);
   }
 
   /* ---- Table of contents ---- */
@@ -299,12 +384,14 @@
     color: var(--manti-text-subtle);
   }
 
-  .docs-prose a:not(.docs-plain) {
+  /* Inline prose links only — wrapper links (.docs-plain cards, .docs-release
+     rows) keep their own styling and must not pick up the underline/link color. */
+  .docs-prose a:not(.docs-plain):not(.docs-release) {
     color: var(--manti-link);
     text-decoration: none;
     text-underline-offset: 0.2em;
   }
-  .docs-prose a:not(.docs-plain):hover {
+  .docs-prose a:not(.docs-plain):not(.docs-release):hover {
     text-decoration: underline;
   }
   .docs-prose strong {
@@ -427,6 +514,13 @@
   .docs-demo-canvas.is-center {
     justify-content: center;
   }
+  /* Demos whose inline dropdown opens downward (e.g. NavigationMenu) top-align
+     the preview and reserve room below, so the open panel stays fully visible
+     instead of being clipped by the demo's rounded overflow. */
+  .docs-demo-canvas.is-roomy {
+    align-items: flex-start;
+    min-block-size: 16rem;
+  }
 
   .docs-demo-canvas :is(h1, h2, h3, h4, h5, h6) {
     margin: revert-layer;
@@ -490,7 +584,7 @@
     color: inherit;
     text-decoration: none;
   }
-  
+
   .docs-card-grid .docs-plain,
   .docs-card-grid .docs-plain > * {
     height: 100%;

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -7,7 +7,11 @@ export interface DocFrontmatter {
   group?: string;
   /** Sort order within the group. */
   order?: number;
+  /** Small sidebar tag for the page, e.g. `New` or `Beta`. */
+  badge?: string;
   description?: string;
+  /** Release date (ISO, quoted in frontmatter), used by update pages. */
+  date?: string;
 }
 
 /** A heading entry from `@stefanprobst/rehype-extract-toc`. */

--- a/packages/docs/src/vite-env.d.ts
+++ b/packages/docs/src/vite-env.d.ts
@@ -20,3 +20,6 @@ declare module 'virtual:manti-search' {
   }[];
   export default docs;
 }
+
+/** Published Manti UI version, injected at build time (see vite.config.ts). */
+declare const __MANTI_VERSION__: string;

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import mdx from '@mdx-js/rollup';
 import rehypeShiki from '@shikijs/rehype';
 import withTocExport from '@stefanprobst/rehype-extract-toc/mdx';
@@ -25,7 +27,18 @@ const evergreen = {
   safari: (17 << 16) | (5 << 8),
 };
 
+// Stamp the published Manti version (from @manti-ui/react) into the bundle so the
+// docs header can render a version badge that tracks the release automatically.
+const mantiVersion = (
+  JSON.parse(
+    readFileSync(new URL('../react/package.json', import.meta.url), 'utf8'),
+  ) as { version: string }
+).version;
+
 export default defineConfig({
+  define: {
+    __MANTI_VERSION__: JSON.stringify(mantiVersion),
+  },
   plugins: [
     // MDX must run before the React plugin so `.mdx` is compiled to JSX first.
     {

--- a/packages/folds/package.json
+++ b/packages/folds/package.json
@@ -48,6 +48,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tanstack/table-core": "^8.21.3",
     "@zag-js/accordion": "^1.41.2",
     "@zag-js/avatar": "^1.41.2",
     "@zag-js/carousel": "^1.41.2",

--- a/packages/folds/package.json
+++ b/packages/folds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/folds",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Framework-agnostic Zag.js behavior contracts for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/folds/src/index.ts
+++ b/packages/folds/src/index.ts
@@ -46,6 +46,14 @@ export * as floatingPanel from '@zag-js/floating-panel';
  */
 export * as swipe from './swipe';
 
+/**
+ * Headless data behaviors. Not from Zag.js — Zag has no table machine, so the
+ * Data Table is built on TanStack `table-core`, the same headless/agnostic shape
+ * (logic-only brain + per-framework adapter). The shared column/types contract
+ * lives here; renderers add their framework adapter (`@tanstack/react-table`, …).
+ */
+export * as table from './table';
+
 export const mantiBehaviorContract = {
   packageName: '@manti-ui/folds',
   engine: 'Zag.js',

--- a/packages/folds/src/table/index.ts
+++ b/packages/folds/src/table/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Headless table behavior — TanStack `@tanstack/table-core`.
+ *
+ * Like a Zag.js machine, table-core is the framework-agnostic brain: it owns
+ * column definitions, sorting, filtering, pagination, grouping, and selection
+ * state, and renders nothing. Each framework renderer wires it up with its own
+ * adapter (`@tanstack/react-table`, `@tanstack/vue-table`, …) and writes the
+ * markup. Re-exporting the contract here keeps column-definition types and the
+ * row-model helpers shared across every future Manti renderer.
+ */
+export * from '@tanstack/table-core';
+
+import type { RowData } from '@tanstack/table-core';
+
+// Manti adds one convention to the column contract: `meta.align`, a shared
+// horizontal-alignment hint every renderer maps onto its header and cells.
+// Declared here so the augmentation travels with the contract, not per renderer.
+declare module '@tanstack/table-core' {
+  // Names must match the original ColumnMeta declaration verbatim (TS2428), even
+  // though `align` doesn't reference them — hence the targeted lint exception.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    /** Horizontal alignment for this column's header and cells. */
+    align?: 'start' | 'center' | 'end';
+  }
+}

--- a/packages/folds/vite.config.ts
+++ b/packages/folds/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: [/^@zag-js\//],
+      external: [/^@zag-js\//, /^@tanstack\//],
     },
   },
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@manti-ui/folds": "workspace:^",
     "@manti-ui/tokens": "workspace:^",
+    "@tanstack/react-table": "^8.21.3",
     "@zag-js/react": "^1.41.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React adapter for the Manti UI design system.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -27,6 +27,8 @@ export interface CheckboxProps {
   readOnly?: boolean;
   name?: string;
   value?: string;
+  /** Accessible name for the control when there is no visible label. */
+  'aria-label'?: string;
   id?: string;
   className?: string;
 }
@@ -51,6 +53,7 @@ export function Checkbox({
   readOnly,
   name,
   value,
+  'aria-label': ariaLabel,
 }: CheckboxProps) {
   const autoId = useId();
   const service = useMachine(checkbox.machine, {
@@ -76,7 +79,11 @@ export function Checkbox({
       data-tone={tone}
       className={cx(className)}
     >
-      <input {...api.getHiddenInputProps()} data-part="hidden-input" />
+      <input
+        {...api.getHiddenInputProps()}
+        data-part="hidden-input"
+        aria-label={ariaLabel}
+      />
       <span {...api.getControlProps()}>
         <span {...api.getIndicatorProps()}>
           <svg viewBox="0 0 24 24" aria-hidden>

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -140,20 +140,24 @@ export function Combobox({
           </svg>
         </button>
       </div>
-      <Portal>
-        <div {...api.getPositionerProps()}>
-          <ScrollArea focusable={false}>
-            <ul {...api.getContentProps()}>
-              {filtered.map((item) => (
-                <li key={item.value} {...api.getItemProps({ item })}>
-                  <span {...api.getItemTextProps({ item })}>{item.label}</span>
-                  <span {...api.getItemIndicatorProps({ item })}>{check}</span>
-                </li>
-              ))}
-            </ul>
-          </ScrollArea>
-        </div>
-      </Portal>
+      {api.open && (
+        <Portal>
+          <div {...api.getPositionerProps()}>
+            <ScrollArea focusable={false}>
+              <ul {...api.getContentProps()}>
+                {filtered.map((item) => (
+                  <li key={item.value} {...api.getItemProps({ item })}>
+                    <span {...api.getItemTextProps({ item })}>{item.label}</span>
+                    <span {...api.getItemIndicatorProps({ item })}>
+                      {check}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </ScrollArea>
+          </div>
+        </Portal>
+      )}
     </div>
   );
 }

--- a/packages/react/src/components/DataTable/DataTable.stories.tsx
+++ b/packages/react/src/components/DataTable/DataTable.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Badge } from '../Badge/Badge';
+import { DataTable } from './DataTable';
+import type { DataTableColumn } from './DataTable';
+
+interface Invoice {
+  id: string;
+  customer: string;
+  status: 'paid' | 'pending' | 'overdue';
+  amount: number;
+}
+
+const data: Invoice[] = [
+  { id: 'INV-001', customer: 'Acme Corp', status: 'paid', amount: 1200 },
+  { id: 'INV-002', customer: 'Globex', status: 'pending', amount: 450.5 },
+  { id: 'INV-003', customer: 'Initech', status: 'overdue', amount: 3120 },
+  { id: 'INV-004', customer: 'Umbrella', status: 'paid', amount: 88 },
+  { id: 'INV-005', customer: 'Soylent', status: 'pending', amount: 640 },
+];
+
+const statusTone = {
+  paid: 'success',
+  pending: 'warning',
+  overdue: 'danger',
+} as const;
+
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+const columns: DataTableColumn<Invoice>[] = [
+  { accessorKey: 'id', header: 'Invoice' },
+  { accessorKey: 'customer', header: 'Customer' },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ getValue }) => {
+      const status = getValue<Invoice['status']>();
+      return (
+        <Badge tone={statusTone[status]} variant="soft">
+          {status}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: 'amount',
+    header: 'Amount',
+    meta: { align: 'end' },
+    cell: ({ getValue }) => currency.format(getValue<number>()),
+  },
+];
+
+const manyInvoices: Invoice[] = Array.from({ length: 24 }, (_, index) => ({
+  id: `INV-${String(index + 1).padStart(3, '0')}`,
+  customer: ['Acme Corp', 'Globex', 'Initech', 'Umbrella', 'Soylent', 'Hooli'][
+    index % 6
+  ],
+  status: (['paid', 'pending', 'overdue'] as const)[index % 3],
+  amount: ((index * 137) % 900) + 40,
+}));
+
+const meta = {
+  title: 'Components/DataTable',
+  component: DataTable,
+  parameters: { layout: 'padded' },
+  args: { columns, data },
+} satisfies Meta<typeof DataTable<Invoice>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Sortable: Story = {
+  args: { sortable: true },
+};
+
+export const ZebraSticky: Story = {
+  args: { zebra: true, interactive: true, sortable: true },
+};
+
+export const Sizes: Story = {
+  args: { size: 'sm', sortable: true, zebra: true },
+};
+
+export const Filterable: Story = {
+  args: { filterable: true, sortable: true },
+};
+
+export const Selectable: Story = {
+  args: {
+    selectable: true,
+    onSelectionChange: (rows) => console.log('selected', rows),
+  },
+};
+
+export const Paginated: Story = {
+  args: { data: manyInvoices, paginated: true, pageSize: 6, sortable: true },
+};
+
+export const FullFeatured: Story = {
+  args: {
+    data: manyInvoices,
+    title: 'Invoices',
+    sortable: true,
+    filterable: true,
+    paginated: true,
+    pageSize: 6,
+    selectable: true,
+    zebra: true,
+    interactive: true,
+  },
+};
+
+export const Empty: Story = {
+  args: { data: [], emptyContent: 'No invoices yet.' },
+};

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { table as tableContract } from '@manti-ui/folds';
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import { cx, dataBool } from '../../internal/props';
+import { Checkbox } from '../Checkbox/Checkbox';
+import { Pagination } from '../Pagination/Pagination';
+import { TextField } from '../TextField/TextField';
+
+/**
+ * A column definition — TanStack's `ColumnDef`, re-exported so consumers type
+ * their columns without depending on `@tanstack/*` directly. Set `meta.align`
+ * (`'start' | 'center' | 'end'`) to align a column's header and cells.
+ */
+export type DataTableColumn<TData, TValue = unknown> = tableContract.ColumnDef<
+  TData,
+  TValue
+>;
+
+export type DataTableSize = 'sm' | 'md' | 'lg';
+
+export interface DataTableProps<TData> {
+  /** Column definitions. Each is a TanStack `ColumnDef` (`DataTableColumn`). */
+  columns: DataTableColumn<TData>[];
+  /** The rows to render. */
+  data: TData[];
+  /** Enable click-to-sort headers (one column at a time). */
+  sortable?: boolean;
+  /** A heading shown at the start of the toolbar; also names the table. */
+  title?: ReactNode;
+  /** Add a global search box that filters across every column. */
+  filterable?: boolean;
+  /** Placeholder for the search box. */
+  filterPlaceholder?: string;
+  /** Paginate client-side, with a Manti Pagination control in the footer. */
+  paginated?: boolean;
+  /** Rows per page when `paginated`. */
+  pageSize?: number;
+  /** Add a leading checkbox column for row selection. */
+  selectable?: boolean;
+  /** Called with the selected rows whenever the selection changes. */
+  onSelectionChange?: (rows: TData[]) => void;
+  /** Row density. */
+  size?: DataTableSize;
+  /** Pin the header to the top while the body scrolls (needs a bounded height). */
+  stickyHeader?: boolean;
+  /** Tint alternating rows. */
+  zebra?: boolean;
+  /** Highlight rows on hover. Pair with real row semantics if rows are clickable. */
+  interactive?: boolean;
+  /** Optional table caption, rendered above the grid. */
+  caption?: ReactNode;
+  /** Shown in place of rows when there are no rows. Defaults to “No data”. */
+  emptyContent?: ReactNode;
+  /** Derive a stable row id (defaults to the row index). */
+  getRowId?: (row: TData, index: number) => string;
+  id?: string;
+  className?: string;
+}
+
+const SCOPE = 'data-table';
+const SELECT_COLUMN_ID = '__manti_select';
+
+function SortIndicator({ state }: { state: 'asc' | 'desc' | 'none' }) {
+  return (
+    <svg
+      data-scope={SCOPE}
+      data-part="sort-indicator"
+      data-state={state}
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+    >
+      <path d="M6 3l3.5 4.5h-7z" fill="currentColor" />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+      <path
+        d="M7 1.5a5.5 5.5 0 1 0 3.4 9.82l3.14 3.14 1.06-1.06-3.14-3.14A5.5 5.5 0 0 0 7 1.5Zm0 1.5a4 4 0 1 1 0 8 4 4 0 0 1 0-8Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+// A leading checkbox column. Defined at module scope so its identity is stable
+// across renders; it reaches selection state through the row/table context.
+function selectionColumn<TData>(): DataTableColumn<TData> {
+  return {
+    id: SELECT_COLUMN_ID,
+    enableSorting: false,
+    meta: { align: 'center' },
+    header: ({ table }) => (
+      <Checkbox
+        size="sm"
+        aria-label="Select all rows"
+        checked={table.getIsAllPageRowsSelected()}
+        indeterminate={
+          table.getIsSomePageRowsSelected() &&
+          !table.getIsAllPageRowsSelected()
+        }
+        onCheckedChange={(checked) => table.toggleAllPageRowsSelected(checked)}
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        size="sm"
+        aria-label={`Select row ${row.index + 1}`}
+        checked={row.getIsSelected()}
+        disabled={!row.getCanSelect()}
+        onCheckedChange={(checked) => row.toggleSelected(checked)}
+      />
+    ),
+  };
+}
+
+/**
+ * A data grid backed by the framework-agnostic TanStack `table-core` machine
+ * (via the React adapter). The machine owns sorting, filtering, pagination, and
+ * selection; this adapter renders the semantic `<table>` anatomy and Manti
+ * styling, and composes Manti's own TextField, Pagination, and Checkbox for the
+ * search, pager, and selection controls.
+ */
+export function DataTable<TData>({
+  columns,
+  data,
+  title,
+  sortable = false,
+  filterable = false,
+  filterPlaceholder = 'Search…',
+  paginated = false,
+  pageSize = 10,
+  selectable = false,
+  onSelectionChange,
+  size = 'md',
+  stickyHeader,
+  zebra,
+  interactive,
+  caption,
+  emptyContent,
+  getRowId,
+  id,
+  className,
+}: DataTableProps<TData>) {
+  const [sorting, setSorting] = useState<tableContract.SortingState>([]);
+  const [globalFilter, setGlobalFilter] = useState('');
+  const [rowSelection, setRowSelection] =
+    useState<tableContract.RowSelectionState>({});
+  const [pagination, setPagination] = useState<tableContract.PaginationState>({
+    pageIndex: 0,
+    pageSize,
+  });
+
+  const reactId = useId();
+  const titleId = title != null ? `${id ?? reactId}-title` : undefined;
+
+  const tableColumns = useMemo(
+    () => (selectable ? [selectionColumn<TData>(), ...columns] : columns),
+    [columns, selectable],
+  );
+
+  const table = useReactTable({
+    data,
+    columns: tableColumns,
+    getRowId,
+    enableSorting: sortable,
+    enableRowSelection: selectable,
+    state: {
+      ...(sortable ? { sorting } : {}),
+      ...(filterable ? { globalFilter } : {}),
+      ...(selectable ? { rowSelection } : {}),
+      ...(paginated ? { pagination } : {}),
+    },
+    onSortingChange: sortable ? setSorting : undefined,
+    onGlobalFilterChange: filterable ? setGlobalFilter : undefined,
+    onRowSelectionChange: selectable ? setRowSelection : undefined,
+    onPaginationChange: paginated ? setPagination : undefined,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: sortable ? getSortedRowModel() : undefined,
+    getFilteredRowModel: filterable ? getFilteredRowModel() : undefined,
+    getPaginationRowModel: paginated ? getPaginationRowModel() : undefined,
+  });
+
+  // Surface the selected rows without re-running on every parent render: hold the
+  // callback in a ref and fire only when the selection actually changes.
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  onSelectionChangeRef.current = onSelectionChange;
+  useEffect(() => {
+    if (!selectable) return;
+    onSelectionChangeRef.current?.(
+      table.getSelectedRowModel().rows.map((row) => row.original),
+    );
+  }, [rowSelection, selectable, table]);
+
+  const rows = table.getRowModel().rows;
+  const columnCount = table.getVisibleLeafColumns().length;
+
+  const showPagination = paginated && table.getPageCount() > 1;
+  const showFooter = showPagination || selectable;
+
+  return (
+    <div
+      data-scope={SCOPE}
+      data-part="root"
+      data-size={size}
+      data-sticky={dataBool(stickyHeader)}
+      data-zebra={dataBool(zebra)}
+      data-interactive={dataBool(interactive)}
+      id={id}
+      className={cx(className)}
+    >
+      {(title != null || filterable) && (
+        <div data-scope={SCOPE} data-part="toolbar">
+          {title != null && (
+            <div data-scope={SCOPE} data-part="title" id={titleId}>
+              {title}
+            </div>
+          )}
+          {filterable && (
+            <div data-scope={SCOPE} data-part="search">
+              <TextField
+                size="sm"
+                fullWidth
+                type="search"
+                aria-label="Search"
+                placeholder={filterPlaceholder}
+                value={globalFilter}
+                onChange={(event) => setGlobalFilter(event.target.value)}
+                leadingAddon={<SearchIcon />}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      <div data-scope={SCOPE} data-part="viewport">
+        <table
+          data-scope={SCOPE}
+          data-part="table"
+          aria-labelledby={titleId}
+        >
+          {caption != null && (
+            <caption data-scope={SCOPE} data-part="caption">
+              {caption}
+            </caption>
+          )}
+          <thead data-scope={SCOPE} data-part="header">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id} data-scope={SCOPE} data-part="header-row">
+                {headerGroup.headers.map((header) => {
+                  const align = header.column.columnDef.meta?.align;
+                  const canSort = sortable && header.column.getCanSort();
+                  const sorted = header.column.getIsSorted();
+                  const ariaSort = canSort
+                    ? sorted === 'asc'
+                      ? 'ascending'
+                      : sorted === 'desc'
+                        ? 'descending'
+                        : 'none'
+                    : undefined;
+                  const label = header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      );
+
+                  return (
+                    <th
+                      key={header.id}
+                      data-scope={SCOPE}
+                      data-part="header-cell"
+                      data-align={align}
+                      colSpan={header.colSpan}
+                      scope="col"
+                      aria-sort={ariaSort}
+                    >
+                      {canSort ? (
+                        <button
+                          type="button"
+                          data-scope={SCOPE}
+                          data-part="sort-trigger"
+                          onClick={header.column.getToggleSortingHandler()}
+                        >
+                          {label}
+                          <SortIndicator state={sorted || 'none'} />
+                        </button>
+                      ) : (
+                        label
+                      )}
+                    </th>
+                  );
+                })}
+              </tr>
+            ))}
+          </thead>
+          <tbody data-scope={SCOPE} data-part="body">
+            {rows.length === 0 ? (
+              <tr data-scope={SCOPE} data-part="row">
+                <td
+                  data-scope={SCOPE}
+                  data-part="empty"
+                  colSpan={columnCount || 1}
+                >
+                  {emptyContent ?? 'No data'}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => (
+                <tr
+                  key={row.id}
+                  data-scope={SCOPE}
+                  data-part="row"
+                  data-selected={dataBool(row.getIsSelected())}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td
+                      key={cell.id}
+                      data-scope={SCOPE}
+                      data-part="cell"
+                      data-align={cell.column.columnDef.meta?.align}
+                    >
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {showFooter && (
+        <div data-scope={SCOPE} data-part="footer">
+          {selectable && (
+            <span data-scope={SCOPE} data-part="selection-summary">
+              {table.getSelectedRowModel().rows.length} selected
+            </span>
+          )}
+          {showPagination && (
+            <Pagination
+              size="sm"
+              count={table.getPrePaginationRowModel().rows.length}
+              pageSize={pagination.pageSize}
+              page={pagination.pageIndex + 1}
+              onPageChange={(page) => table.setPageIndex(page - 1)}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -141,20 +141,24 @@ export function Select({
           </span>
         </button>
       </div>
-      <Portal>
-        <div {...api.getPositionerProps()}>
-          <ScrollArea focusable={false}>
-            <ul {...api.getContentProps()}>
-              {items.map((item) => (
-                <li key={item.value} {...api.getItemProps({ item })}>
-                  <span {...api.getItemTextProps({ item })}>{item.label}</span>
-                  <span {...api.getItemIndicatorProps({ item })}>{check}</span>
-                </li>
-              ))}
-            </ul>
-          </ScrollArea>
-        </div>
-      </Portal>
+      {api.open && (
+        <Portal>
+          <div {...api.getPositionerProps()}>
+            <ScrollArea focusable={false}>
+              <ul {...api.getContentProps()}>
+                {items.map((item) => (
+                  <li key={item.value} {...api.getItemProps({ item })}>
+                    <span {...api.getItemTextProps({ item })}>{item.label}</span>
+                    <span {...api.getItemIndicatorProps({ item })}>
+                      {check}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </ScrollArea>
+          </div>
+        </Portal>
+      )}
       <select {...api.getHiddenSelectProps()}>
         {items.map((item) => (
           <option key={item.value} value={item.value}>

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -37,6 +37,13 @@ export type { ComboboxItem, ComboboxProps } from './Combobox/Combobox';
 export { ContextMenu } from './ContextMenu/ContextMenu';
 export type { ContextMenuProps } from './ContextMenu/ContextMenu';
 
+export { DataTable } from './DataTable/DataTable';
+export type {
+  DataTableColumn,
+  DataTableProps,
+  DataTableSize,
+} from './DataTable/DataTable';
+
 export { DatePicker } from './DatePicker/DatePicker';
 export type { DatePickerProps } from './DatePicker/DatePicker';
 

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         /^react-dom(?:\/.*)?$/,
         /^@manti-ui\//,
         /^@zag-js\//,
+        /^@tanstack\//,
       ],
     },
   },

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/styles",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Framework-agnostic CSS for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/styles/src/components/data-table.css
+++ b/packages/styles/src/components/data-table.css
@@ -1,0 +1,231 @@
+/**
+ * Data Table — a TanStack-backed data grid. The table-core machine owns sorting,
+ * filtering, pagination, and selection; this layer dresses the anatomy in the
+ * Manti signature: a translucent panel that frames an optional toolbar, a
+ * scrollable grid viewport, and an optional footer. The body is hairline-
+ * separated, the header can stick, rows can stripe, and selected rows tint.
+ *
+ * `border-collapse: separate` (not collapse) is deliberate — collapsed borders
+ * detach from sticky headers on scroll in several engines, so separators live on
+ * the cells instead. The panel chrome (border/radius/clip) sits on `root`; the
+ * horizontal/vertical scroll sits on `viewport` so the toolbar and footer stay
+ * pinned outside it.
+ */
+@layer manti.components {
+  [data-scope='data-table'][data-part='root'] {
+    /* Component tokens (Tier 3) — public per-component override surface; default to semantic tokens. See docs/styling.md. */
+    --manti-data-table-radius: var(--manti-radius-lg);
+    --manti-data-table-cell-padding-x: var(--manti-space-4);
+    --manti-data-table-cell-padding-y: var(--manti-space-3);
+    --manti-data-table-font-size: var(--manti-text-sm);
+    --manti-data-table-header-font-size: var(--manti-text-xs);
+
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    overflow: clip;
+    background: var(--manti-panel-tint);
+    -webkit-backdrop-filter: var(--manti-panel-blur);
+    backdrop-filter: var(--manti-panel-blur);
+    border: 1px solid var(--manti-panel-border);
+    border-radius: var(--manti-data-table-radius);
+    box-shadow: inset 0 1px 0 0 var(--manti-panel-highlight);
+  }
+
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    [data-scope='data-table'][data-part='root'] {
+      background: var(--manti-surface);
+    }
+  }
+
+  [data-scope='data-table'][data-part='toolbar'] {
+    display: flex;
+    align-items: center;
+    gap: var(--manti-space-3);
+    padding: var(--manti-space-3) var(--manti-data-table-cell-padding-x);
+    border-bottom: 1px solid var(--manti-border);
+  }
+
+  [data-scope='data-table'][data-part='title'] {
+    margin: 0;
+    color: var(--manti-text);
+    font-size: var(--manti-text-base);
+    font-weight: var(--manti-weight-semibold);
+    line-height: var(--manti-leading-snug);
+  }
+
+  /* Search sits at the trailing edge; with a title present it pairs left↔right. */
+  [data-scope='data-table'][data-part='search'] {
+    margin-inline-start: auto;
+    inline-size: min(100%, 18rem);
+  }
+
+  [data-scope='data-table'][data-part='viewport'] {
+    overflow: auto;
+  }
+
+  [data-scope='data-table'][data-part='table'] {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    color: var(--manti-text);
+    font-size: var(--manti-data-table-font-size);
+    line-height: var(--manti-leading-snug);
+    text-align: start;
+  }
+
+  [data-scope='data-table'][data-part='caption'] {
+    caption-side: top;
+    padding: var(--manti-data-table-cell-padding-y)
+      var(--manti-data-table-cell-padding-x);
+    color: var(--manti-text-muted);
+    font-size: var(--manti-data-table-header-font-size);
+    font-weight: var(--manti-weight-medium);
+    text-align: start;
+  }
+
+  [data-scope='data-table'][data-part='header-cell'] {
+    padding: var(--manti-data-table-cell-padding-y)
+      var(--manti-data-table-cell-padding-x);
+    background: var(--manti-bg-subtle);
+    border-bottom: 1px solid var(--manti-border-strong);
+    color: var(--manti-text-subtle);
+    font-size: var(--manti-data-table-header-font-size);
+    font-weight: var(--manti-weight-semibold);
+    letter-spacing: 0.02em;
+    text-align: start;
+    white-space: nowrap;
+    vertical-align: middle;
+  }
+
+  /* Sticky header: cells pin to the top of the scrolling viewport. */
+  [data-scope='data-table'][data-part='root'][data-sticky='true']
+    [data-part='header-cell'] {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  [data-scope='data-table'][data-part='sort-trigger'] {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--manti-space-1);
+    margin: 0;
+    padding: 0;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    text-align: inherit;
+    cursor: pointer;
+    transition: color var(--manti-duration-fast) var(--manti-ease-smooth);
+
+    &:hover {
+      color: var(--manti-text);
+    }
+
+    &:focus-visible {
+      outline: var(--manti-focus-ring-width) solid var(--manti-focus-ring);
+      outline-offset: var(--manti-focus-ring-offset);
+      border-radius: var(--manti-radius-xs);
+    }
+  }
+
+  [data-scope='data-table'][data-part='sort-indicator'] {
+    flex: none;
+    width: 0.85em;
+    height: 0.85em;
+    opacity: 0.35;
+    transition:
+      transform var(--manti-duration-base) var(--manti-ease-smooth),
+      opacity var(--manti-duration-fast) var(--manti-ease-smooth);
+
+    &[data-state='asc'] {
+      opacity: 1;
+    }
+
+    &[data-state='desc'] {
+      opacity: 1;
+      transform: rotate(180deg);
+    }
+  }
+
+  [data-scope='data-table'][data-part='cell'] {
+    padding: var(--manti-data-table-cell-padding-y)
+      var(--manti-data-table-cell-padding-x);
+    border-bottom: 1px solid var(--manti-border);
+    vertical-align: middle;
+    text-align: start;
+  }
+
+  [data-scope='data-table'][data-part='row']:last-child [data-part='cell'] {
+    border-bottom: none;
+  }
+
+  /* Alignment — driven by each column's `meta.align`. */
+  [data-scope='data-table'][data-part='header-cell'][data-align='center'],
+  [data-scope='data-table'][data-part='cell'][data-align='center'] {
+    text-align: center;
+  }
+  [data-scope='data-table'][data-part='header-cell'][data-align='end'],
+  [data-scope='data-table'][data-part='cell'][data-align='end'] {
+    text-align: end;
+  }
+
+  /* Zebra striping (opt-in). Selected rows opt out so their tint always shows. */
+  [data-scope='data-table'][data-part='root'][data-zebra='true']
+    [data-part='row']:nth-child(even):not([data-selected='true'])
+    [data-part='cell'] {
+    background: color-mix(in oklab, var(--manti-text) 3%, transparent);
+  }
+
+  /* Interactive rows highlight on hover (selected rows keep their own tint). */
+  [data-scope='data-table'][data-part='root'][data-interactive='true']
+    [data-part='row']:hover:not([data-selected='true'])
+    [data-part='cell'] {
+    background: color-mix(in oklab, var(--manti-text) 5%, transparent);
+  }
+
+  /* Selected rows — a stronger, exclusive tint (see :not() guards above). */
+  [data-scope='data-table'][data-part='row'][data-selected='true']
+    [data-part='cell'] {
+    background: color-mix(in oklab, var(--manti-text) 8%, transparent);
+  }
+
+  [data-scope='data-table'][data-part='empty'] {
+    padding: var(--manti-space-8) var(--manti-data-table-cell-padding-x);
+    color: var(--manti-text-subtle);
+    text-align: center;
+  }
+
+  [data-scope='data-table'][data-part='footer'] {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--manti-space-3);
+    padding: var(--manti-space-3) var(--manti-data-table-cell-padding-x);
+    border-top: 1px solid var(--manti-border);
+  }
+
+  /* Pushes the pagination to the trailing edge; alone, it sits at the start. */
+  [data-scope='data-table'][data-part='selection-summary'] {
+    margin-inline-end: auto;
+    color: var(--manti-text-muted);
+    font-size: var(--manti-data-table-header-font-size);
+  }
+
+  /* Density presets re-target the public cell tokens. */
+  [data-scope='data-table'][data-part='root'][data-size='sm'] {
+    --manti-data-table-cell-padding-x: var(--manti-space-3);
+    --manti-data-table-cell-padding-y: var(--manti-space-2);
+    --manti-data-table-font-size: var(--manti-text-xs);
+  }
+  [data-scope='data-table'][data-part='root'][data-size='lg'] {
+    --manti-data-table-cell-padding-x: var(--manti-space-5);
+    --manti-data-table-cell-padding-y: var(--manti-space-4);
+    --manti-data-table-font-size: var(--manti-text-base);
+  }
+}

--- a/packages/styles/src/index.css
+++ b/packages/styles/src/index.css
@@ -61,6 +61,7 @@
 @import './components/navigation-menu.css';
 @import './components/floating-panel.css';
 @import './components/scroll-area.css';
+@import './components/data-table.css';
 @import './components/marquee.css';
 @import './components/swipe.css';
 

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/tokens",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Framework-agnostic design token contract for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -308,6 +308,13 @@ export const componentTokens = {
   tooltip: ['max-width'],
   tour: ['width'],
   timer: ['item-min-width'],
+  'data-table': [
+    'radius',
+    'cell-padding-x',
+    'cell-padding-y',
+    'font-size',
+    'header-font-size',
+  ],
 } as const;
 
 export type MantiComponentTokens = typeof componentTokens;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
 
   packages/folds:
     dependencies:
+      '@tanstack/table-core':
+        specifier: ^8.21.3
+        version: 8.21.3
       '@zag-js/accordion':
         specifier: ^1.41.2
         version: 1.41.2
@@ -270,6 +273,9 @@ importers:
       '@manti-ui/tokens':
         specifier: workspace:^
         version: link:../tokens
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@zag-js/react':
         specifier: ^1.41.2
         version: 1.41.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1266,6 +1272,17 @@ packages:
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3723,6 +3740,14 @@ snapshots:
   '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/react-table@8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary

Adds **DataTable**, Manti's first non-Zag component, and a substantial docs-site
sidebar overhaul, targeting the **v0.1.1** release.

## DataTable (new component)

Built on **TanStack** instead of Zag (Zag has no table machine), following the
same headless shape Manti already uses: `@manti-ui/folds` re-exports
`@tanstack/table-core` as the framework-agnostic contract (+ a shared
`ColumnMeta.align` augmentation), and `@manti-ui/react` uses the
`@tanstack/react-table` runtime — the parallel to `useMachine` from `@zag-js/react`.

Features:
- **Sorting** — click-to-sort headers with `aria-sort` + direction arrow
- **Filtering** — global search box (composes Manti `TextField`)
- **Pagination** — client-side, composing Manti `Pagination`
- **Selection** — leading checkbox column with select-all/indeterminate (composes Manti `Checkbox`)
- Density sizes, sticky header, zebra, hover, column alignment via `meta.align`
- Optional toolbar `title` (search right-aligned, title left, `aria-labelledby`)
- Semantic `<table>` anatomy, full-width by default, empty state, caption

Ships component tokens, styles, Storybook stories, and a docs page with demos.
`Checkbox` gains an `aria-label` prop. Both `folds` and `react` externalize
`@tanstack/*` in their builds (table-core/react-table are not inlined; react's
`dist/index.js` dropped 166KB → 102KB), so the single installed copy dedupes and
tree-shakes at the consumer.

## Docs

- **Sidebar categorization** — components split into seven categories (Inputs,
  Buttons & Actions, Navigation, Overlays, Feedback, Data Display, Layout) via
  frontmatter `group`.
- **Collapsible groups** — each sidebar category is a Manti `Collapsible` (open
  by default; state persists across in-app navigation).
- **"New" badge** — frontmatter-driven sidebar tag (DataTable is tagged).
- **Changelog** section.
- **fix(navigation-menu)** — the docs demo flyout no longer gets clipped inside
  the playground (a roomy canvas modifier).

## Other

- **fix(combobox,select)** — only mount the portal content while the popup is open.

## Verification

`pnpm verify` (lint + typecheck + all package builds + Storybook) is green; the
docs site builds (71 routes). The styles build's component-token guard passes
(`data-table` registered), and the `light-dark()` / `-webkit-backdrop-filter`
invariants hold.

## Release

Targets **v0.1.1** (packages already bumped; npm currently has only 0.1.0). After
merge, publish via the `v0.1.1` tag (release workflow lives on this base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
