### PR TITLE
feat(docs): tabbed, copyable install snippet on Getting Started

### DIFF
--- a/packages/docs/src/content/getting-started.mdx
+++ b/packages/docs/src/content/getting-started.mdx
@@ -14,17 +14,14 @@ automatically.
 
 ## Install
 
-```bash
-npm install @manti-ui/react @manti-ui/styles
-```
+Install the packages with your package manager of choice:
+
+<InstallTabs packages="@manti-ui/react @manti-ui/styles" />
 
 `@manti-ui/react` pulls in `@manti-ui/tokens` and the behavior machines
 (`@manti-ui/folds`) automatically. `@manti-ui/styles` is a **peer dependency** —
 you install it alongside the renderer, so you stay in control of the CSS version
 and its import order (which matters when you also use Tailwind).
-
-> Using pnpm or Yarn? `pnpm add @manti-ui/react @manti-ui/styles` or
-> `yarn add @manti-ui/react @manti-ui/styles`.
 
 ## Import the styles once
 

--- a/packages/docs/src/doc/InstallTabs.tsx
+++ b/packages/docs/src/doc/InstallTabs.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { Clipboard, Tabs } from '@manti-ui/react';
+
+const DEFAULT_PACKAGES = '@manti-ui/react @manti-ui/styles';
+
+/** Each manager and how it spells "install these packages". */
+const MANAGERS = [
+  { value: 'npm', label: 'npm', install: 'install' },
+  { value: 'yarn', label: 'yarn', install: 'add' },
+  { value: 'pnpm', label: 'pnpm', install: 'add' },
+  { value: 'bun', label: 'bun', install: 'add' },
+];
+
+export interface InstallTabsProps {
+  /**
+   * The package(s) to install, space-separated. Defaults to the two packages a
+   * React app needs (the renderer + the stylesheet).
+   */
+  packages?: string;
+}
+
+/**
+ * A package-manager install snippet framed like the live demos: one bordered
+ * card whose top bar switches managers (npm / yarn / pnpm / bun) and whose body
+ * shows the matching command in Manti's own Clipboard component, copyable in one
+ * click. The Tabs here are only a switcher (their content is hidden); the command
+ * is rendered below from the active manager.
+ */
+export function InstallTabs({ packages = DEFAULT_PACKAGES }: InstallTabsProps) {
+  const [manager, setManager] = useState(MANAGERS[0].value);
+  const active = MANAGERS.find((m) => m.value === manager) ?? MANAGERS[0];
+
+  return (
+    <div className="install-card">
+      <div className="install-card-bar">
+        <Tabs
+          variant="soft"
+          tone="primary"
+          value={manager}
+          onValueChange={setManager}
+          items={MANAGERS.map((m) => ({
+            value: m.value,
+            label: m.label,
+            content: null,
+          }))}
+        />
+      </div>
+      <div className="install-card-body">
+        {/* Coloured for display (a Clipboard <input> can't carry highlighted
+            spans); the adjacent Clipboard holds the raw value and does the copy. */}
+        <code className="install-cmd">
+          <span className="install-cmd-pm">{active.value}</span>{' '}
+          <span className="install-cmd-sub">{active.install}</span> {packages}
+        </code>
+        <Clipboard value={`${active.value} ${active.install} ${packages}`} />
+      </div>
+    </div>
+  );
+}

--- a/packages/docs/src/mdx/MDXComponents.tsx
+++ b/packages/docs/src/mdx/MDXComponents.tsx
@@ -6,6 +6,7 @@ import { Anatomy } from '../doc/Anatomy';
 import { ColorRamps, ToneGallery } from '../doc/ColorRamps';
 import { ComponentStatusGrid } from '../doc/ComponentStatusGrid';
 import { Demo } from '../doc/Demo';
+import { InstallTabs } from '../doc/InstallTabs';
 import { LinkButton } from '../doc/LinkButton';
 import { PropsTable } from '../doc/PropsTable';
 import { ReleasesList } from '../doc/ReleasesList';
@@ -52,6 +53,7 @@ export const mdxComponents = {
   a: Anchor,
   pre: CodeBlock,
   Demo,
+  InstallTabs,
   LinkButton,
   PropsTable,
   Anatomy,

--- a/packages/docs/src/styles/docs.css
+++ b/packages/docs/src/styles/docs.css
@@ -213,8 +213,7 @@
   .docs-nav-group + .docs-nav-group {
     margin-top: var(--manti-space-3);
   }
-  /* Restyle the Manti Collapsible trigger as a minimal, full-width category
-     header (the panel-button default is replaced via the public anatomy). */
+
   .docs-sidebar-nav [data-scope='collapsible'][data-part='trigger'] {
     display: flex;
     width: 100%;
@@ -384,8 +383,6 @@
     color: var(--manti-text-subtle);
   }
 
-  /* Inline prose links only — wrapper links (.docs-plain cards, .docs-release
-     rows) keep their own styling and must not pick up the underline/link color. */
   .docs-prose a:not(.docs-plain):not(.docs-release) {
     color: var(--manti-link);
     text-decoration: none;
@@ -468,18 +465,19 @@
     all: unset;
     font-family: var(--manti-font-mono);
   }
-  /* Shiki emits per-token `--shiki-light` / `--shiki-dark` custom props. */
+
   pre.shiki,
   pre.shiki span {
     color: var(--shiki-light);
-    background-color: var(--shiki-light-bg);
   }
   [data-theme='dark'] pre.shiki,
   [data-theme='dark'] pre.shiki span {
     color: var(--shiki-dark);
-    background-color: var(--shiki-dark-bg);
   }
-  /* only the <pre> carries the surface fill, not every token span */
+
+  pre.shiki {
+    background-color: var(--manti-surface);
+  }
   pre.shiki span {
     background-color: transparent;
   }
@@ -790,5 +788,77 @@
     .docs-nav-menu-button {
       display: none;
     }
+  }
+
+  .install-card {
+    margin: 0 0 var(--manti-space-6);
+    border: 1px solid var(--manti-border);
+    border-radius: var(--manti-radius-lg);
+    overflow: clip;
+    background: var(--manti-surface);
+  }
+  .install-card-bar {
+    display: flex;
+    align-items: center;
+    padding: var(--manti-space-2);
+    border-bottom: 1px solid var(--manti-border);
+  }
+  /* The manager Tabs are a switcher only — hide their (empty) content panel. */
+  .install-card-bar [data-scope='tabs'][data-part='root'] {
+    gap: 0;
+  }
+  .install-card-bar [data-scope='tabs'][data-part='content'] {
+    display: none;
+  }
+  .install-card-bar [data-part='trigger'] {
+    padding: var(--manti-space-1) var(--manti-space-3);
+    font-size: var(--manti-text-sm);
+  }
+  .install-card-body {
+    display: flex;
+    align-items: center;
+    gap: var(--manti-space-2);
+    padding: var(--manti-space-3) var(--manti-space-4);
+    background: transparent;
+  }
+
+  .install-card-body .install-cmd {
+    flex: 1;
+    min-width: 0;
+    overflow-x: auto;
+    white-space: nowrap;
+    padding: 0;
+    background: none;
+    border-radius: 0;
+    color: var(--manti-text);
+    font-family: var(--manti-font-mono);
+    font-size: var(--manti-text-sm);
+  }
+  .install-card-body .install-cmd-pm {
+    color: light-dark(#8250df, #d2a8ff);
+  }
+  .install-card-body .install-cmd-sub {
+    color: light-dark(#0550ae, #79c0ff);
+  }
+
+  .install-card-body [data-scope='clipboard'][data-part='root'] {
+    flex: none;
+  }
+  .install-card-body [data-scope='clipboard'][data-part='input'] {
+    display: none;
+  }
+  .install-card-body [data-scope='clipboard'][data-part='control'] {
+    min-height: 0;
+    padding: 0;
+    background: none;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    border: none;
+    box-shadow: none;
+  }
+  .install-card-body [data-scope='clipboard'][data-part='trigger'] {
+    width: auto;
+    padding-inline: var(--manti-space-1);
+    border-inline-start: none;
   }
 }


### PR DESCRIPTION
Replace the static install code block with InstallTabs: a Manti Tabs switcher (npm/yarn/pnpm/bun) over a Manti Clipboard copy, framed like the demos with the bar on top. The command is syntax-coloured and sits flat on the card. Unify the Shiki code-block surfaces to --manti-surface so the snippet and the import/theme blocks share one background.