### PR TITLE
fix(color-picker): center slider thumb + add showValueText prop

### DIFF
--- a/.changeset/color-picker-slider-thumb.md
+++ b/.changeset/color-picker-slider-thumb.md
@@ -1,0 +1,10 @@
+---
+'@manti-ui/styles': patch
+'@manti-ui/react': patch
+---
+
+**ColorPicker** — center the hue/alpha slider thumb (it previously sat low
+because Zag positions the channel thumb with `top: 50%` but adds no centering
+transform, unlike the area thumb) and stop the slider track from clipping it.
+Add a `showValueText` prop (default `true`) so the trigger can show only the
+color swatch, hiding the formatted value text.

--- a/packages/docs/src/content/changelog/v0-1-0.mdx
+++ b/packages/docs/src/content/changelog/v0-1-0.mdx
@@ -2,7 +2,7 @@
 title: v0.1.0
 slug: /changelog/v0.1.0
 group: Changelog
-order: 3
+order: 4
 date: '2026-06-23'
 description: The first public release of Manti UI.
 ---

--- a/packages/docs/src/content/changelog/v0-1-1.mdx
+++ b/packages/docs/src/content/changelog/v0-1-1.mdx
@@ -2,7 +2,7 @@
 title: v0.1.1
 slug: /changelog/v0.1.1
 group: Changelog
-order: 2
+order: 3
 date: '2026-06-26'
 description: A TanStack-backed DataTable, a categorized and collapsible docs sidebar, the panel token rename, scrollable Combobox and Select listboxes, a Carousel slide-gap token, and overlay fixes.
 ---

--- a/packages/docs/src/content/changelog/v0-1-2.mdx
+++ b/packages/docs/src/content/changelog/v0-1-2.mdx
@@ -2,7 +2,7 @@
 title: v0.1.2
 slug: /changelog/v0.1.2
 group: Changelog
-order: 1
+order: 2
 date: '2026-06-29'
 description: A new Textarea multiline field, per-node TreeView icons, scrollable TimePicker columns, a tonal Listbox selection, and Combobox and TagsInput refinements.
 ---

--- a/packages/docs/src/content/changelog/v0-1-3.mdx
+++ b/packages/docs/src/content/changelog/v0-1-3.mdx
@@ -1,0 +1,25 @@
+---
+title: v0.1.3
+slug: /changelog/v0.1.3
+group: Changelog
+order: 1
+date: '2026-07-01'
+description: A centered ColorPicker slider thumb and an optional swatch-only trigger.
+---
+
+# v0.1.3
+
+_Released 2026-07-01._
+
+## Fixed
+
+- **ColorPicker** — the hue and alpha slider thumbs now sit centered on the
+  track. They previously hung low because Zag positions the channel-slider thumb
+  with `top: 50%` but, unlike the area thumb, adds no centering transform; the
+  track also no longer clips the taller thumb.
+
+## Added
+
+- **ColorPicker** — a `showValueText` prop (default `true`). Set it to `false` to
+  show only the color swatch in the trigger, hiding the formatted value text
+  (e.g. `rgba(124, 58, 237, 1)`).

--- a/packages/docs/src/data/components/color-picker.ts
+++ b/packages/docs/src/data/components/color-picker.ts
@@ -26,6 +26,13 @@ export const meta: ComponentMeta = {
         'Called whenever the value changes; emits a CSS color string.',
     },
     {
+      name: 'showValueText',
+      type: 'boolean',
+      default: 'true',
+      description:
+        'Show the formatted value text (e.g. rgba(...)) next to the swatch in the trigger. Set to false to show only the color swatch.',
+    },
+    {
       name: 'placement',
       type: 'Placement',
       default: `'bottom-start'`,

--- a/packages/react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -17,3 +17,8 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {};
+
+/** Trigger shows only the color swatch, hiding the formatted value text. */
+export const SwatchOnly: Story = {
+  args: { showValueText: false },
+};

--- a/packages/react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.tsx
@@ -15,6 +15,12 @@ export interface ColorPickerProps {
   defaultValue?: string;
   /** Called whenever the value changes; emits a CSS color string. */
   onValueChange?: (value: string) => void;
+  /**
+   * Show the formatted value text (e.g. `rgba(124, 58, 237, 1)`) next to the
+   * swatch in the trigger. Set to `false` to show only the color swatch.
+   * Defaults to `true`.
+   */
+  showValueText?: boolean;
   /** Placement of the panel relative to the control. */
   placement?: Placement;
   disabled?: boolean;
@@ -30,6 +36,7 @@ export function ColorPicker({
   value,
   defaultValue = '#7c3aed',
   onValueChange,
+  showValueText = true,
   placement = 'bottom-start',
   disabled,
   name,
@@ -62,12 +69,14 @@ export function ColorPicker({
     <div {...api.getRootProps()} className={cx(className)}>
       {label != null && <label {...api.getLabelProps()}>{label}</label>}
       <div {...api.getControlProps()}>
-        <button {...api.getTriggerProps()}>
+        <button {...api.getTriggerProps()} data-value-text={showValueText}>
           <span
             data-part="value-swatch"
             style={{ background: api.valueAsString }}
           />
-          <span {...api.getValueTextProps()}>{api.valueAsString}</span>
+          {showValueText && (
+            <span {...api.getValueTextProps()}>{api.valueAsString}</span>
+          )}
         </button>
       </div>
       <Portal>

--- a/packages/styles/src/components/color-picker.css
+++ b/packages/styles/src/components/color-picker.css
@@ -42,6 +42,12 @@
       outline: var(--manti-focus-ring-width) solid var(--tone-ring);
       outline-offset: var(--manti-focus-ring-offset);
     }
+
+    /* Swatch-only trigger (showValueText={false}) — no value text to balance,
+       so tighten to symmetric padding around the lone swatch. */
+    &[data-value-text='false'] {
+      padding-inline: var(--manti-space-2);
+    }
   }
 
   [data-scope='color-picker'][data-part='root'] [data-part='value-swatch'] {
@@ -111,12 +117,14 @@
     position: relative;
     height: 0.75rem;
     border-radius: var(--manti-radius-full);
-    overflow: hidden;
+    /* No overflow:hidden here — the thumb is taller than the track and must not
+       be clipped; the track and transparency grid round their own corners. */
   }
 
   [data-scope='color-picker'][data-part='channel-slider-track'] {
     width: 100%;
     height: 100%;
+    border-radius: var(--manti-radius-full);
   }
 
   [data-scope='color-picker'][data-part='channel-slider-thumb'] {
@@ -125,6 +133,9 @@
     border: 2px solid var(--manti-gray-50);
     border-radius: var(--manti-radius-full);
     box-shadow: var(--manti-shadow-md);
+    /* Zag positions the thumb with top:50%/left:X% but (unlike the area thumb)
+       adds no centering transform, so we recenter it onto that point here. */
+    transform: translate(-50%, -50%);
   }
 
   [data-scope='color-picker'][data-part='transparency-grid'] {


### PR DESCRIPTION
## What

Two ColorPicker fixes, released as **v0.1.3** (patch — a `.changeset` is included so the release automation bumps all four `@manti-ui/*` packages in lockstep once this reaches `main`).

### Fixed — slider thumb was off-center
The hue/alpha slider thumbs sat low. Root cause: Zag positions the channel-slider thumb with `top: 50%; left: X%` but, unlike the area thumb, adds **no** centering transform. The CSS didn't supply one either, so the thumb's top-left corner landed on the center point and it hung down. Also `overflow: hidden` on the slider clipped the taller (0.875rem) thumb inside the 0.75rem track.

- Add `transform: translate(-50%, -50%)` to `channel-slider-thumb`.
- Drop `overflow: hidden` from `channel-slider`; round the track/transparency-grid on their own so the thumb isn't clipped.

### Added — `showValueText` prop
The trigger showed `[swatch][rgba(...)]` with no way to hide the text. This is a pure render/anatomy concern (not Zag state), so it lives in the React adapter, not the machine.

- New `showValueText?: boolean` (default `true`); `false` renders only the swatch.
- Trigger gets `data-value-text`; swatch-only tightens to symmetric padding.
- New `SwatchOnly` story + docs prop-table entry.

## Release
- `.changeset/color-picker-slider-thumb.md` (patch → **0.1.3** from 0.1.2).
- `packages/docs/src/content/changelog/v0-1-3.mdx` added; existing releases' `order` bumped so v0.1.3 sorts newest (keeps the docs "what's new" badge from 404-ing on publish).
- Publish happens automatically when `dev` → `main` merges and the Changesets "version packages" PR is merged.

## Verification
- `pnpm verify` green (lint + typecheck + build).
- `pnpm --filter @manti-ui/docs build` compiles the new MDX (74 prerendered routes).
- Styles dist gotchas intact: `-webkit-backdrop-filter` present, no `prefers-color-scheme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)