### PR TITLE
feat(splitter): handle widens without reflow + component tokens

### DIFF
--- a/.changeset/splitter-handle-tokens.md
+++ b/.changeset/splitter-handle-tokens.md
@@ -1,0 +1,13 @@
+---
+'@manti-ui/tokens': patch
+'@manti-ui/styles': patch
+---
+
+**Splitter** — rework the resize handle so it grows visually without reflowing
+the panels: the trigger is now a fixed-width grab track holding a thin line
+(drawn with `::before`) that tones and widens via an outline on hover/drag,
+instead of animating the track's own width. The widen/tone is keyed on
+`:hover`/`[data-dragging]` (not `[data-focus]`) so the handle no longer stays
+stuck in the active tone after a mouse drag ends. Adds three component tokens —
+`--manti-splitter-handle-size`, `--manti-splitter-line-size`, and
+`--manti-splitter-line-size-active`.

--- a/docs/component-tokens.md
+++ b/docs/component-tokens.md
@@ -112,6 +112,9 @@ component token only to make one component diverge on purpose — see
 | `slider`            | `--manti-slider-length`                     | `12rem`                          |
 | `spinner`           | `--manti-spinner-size`                      | `1.25rem`                        |
 | `spinner`           | `--manti-spinner-thickness`                 | `2px`                            |
+| `splitter`          | `--manti-splitter-handle-size`              | `0.375rem`                       |
+| `splitter`          | `--manti-splitter-line-size`                | `0.125rem`                       |
+| `splitter`          | `--manti-splitter-line-size-active`         | `0.625rem`                       |
 | `steps`             | `--manti-steps-indicator-size`              | `2rem`                           |
 | `switch`            | `--manti-switch-track-width`                | `2.75rem`                        |
 | `switch`            | `--manti-switch-track-height`               | `1.5rem`                         |

--- a/packages/docs/src/content/changelog/v0-1-0.mdx
+++ b/packages/docs/src/content/changelog/v0-1-0.mdx
@@ -2,7 +2,7 @@
 title: v0.1.0
 slug: /changelog/v0.1.0
 group: Changelog
-order: 4
+order: 5
 date: '2026-06-23'
 description: The first public release of Manti UI.
 ---

--- a/packages/docs/src/content/changelog/v0-1-1.mdx
+++ b/packages/docs/src/content/changelog/v0-1-1.mdx
@@ -2,7 +2,7 @@
 title: v0.1.1
 slug: /changelog/v0.1.1
 group: Changelog
-order: 3
+order: 4
 date: '2026-06-26'
 description: A TanStack-backed DataTable, a categorized and collapsible docs sidebar, the panel token rename, scrollable Combobox and Select listboxes, a Carousel slide-gap token, and overlay fixes.
 ---

--- a/packages/docs/src/content/changelog/v0-1-2.mdx
+++ b/packages/docs/src/content/changelog/v0-1-2.mdx
@@ -2,7 +2,7 @@
 title: v0.1.2
 slug: /changelog/v0.1.2
 group: Changelog
-order: 2
+order: 3
 date: '2026-06-29'
 description: A new Textarea multiline field, per-node TreeView icons, scrollable TimePicker columns, a tonal Listbox selection, and Combobox and TagsInput refinements.
 ---

--- a/packages/docs/src/content/changelog/v0-1-3.mdx
+++ b/packages/docs/src/content/changelog/v0-1-3.mdx
@@ -2,7 +2,7 @@
 title: v0.1.3
 slug: /changelog/v0.1.3
 group: Changelog
-order: 1
+order: 2
 date: '2026-07-01'
 description: A centered ColorPicker slider thumb and an optional swatch-only trigger.
 ---

--- a/packages/docs/src/content/changelog/v0-1-4.mdx
+++ b/packages/docs/src/content/changelog/v0-1-4.mdx
@@ -1,0 +1,27 @@
+---
+title: v0.1.4
+slug: /changelog/v0.1.4
+group: Changelog
+order: 1
+date: '2026-07-01'
+description: A reworked Splitter resize handle that widens without reflowing panels, plus three Splitter component tokens.
+---
+
+# v0.1.4
+
+_Released 2026-07-01._
+
+## Changed
+
+- **Splitter** — the resize handle no longer reflows the panels when it grows.
+  The trigger is now a fixed-width grab track holding a thin line that tones and
+  widens via an outline on hover/drag, rather than animating the track's own
+  width. The active state is keyed on hover/drag instead of focus, so the handle
+  no longer stays stuck in the active tone after a mouse drag ends.
+
+## Added
+
+- **Splitter** — three component tokens for the handle:
+  `--manti-splitter-handle-size` (the grab-track thickness),
+  `--manti-splitter-line-size` (the resting line), and
+  `--manti-splitter-line-size-active` (the widened band on hover/drag).

--- a/packages/styles/src/components/splitter.css
+++ b/packages/styles/src/components/splitter.css
@@ -1,7 +1,9 @@
 /**
  * Splitter — a resizable split layout backed by the Zag.js splitter machine.
- * Panels are framed surfaces; the resize trigger is a slim handle that thickens
- * and tones on hover/drag.
+ * Panels are framed surfaces; the resize trigger is a fixed-width track holding
+ * a slim line that tones and widens on hover/drag. The widening is drawn with an
+ * outline on the line (not extra width) so the handle grows visually without
+ * reflowing the panels.
  */
 @layer manti.components {
   [data-scope='splitter'][data-part='root'] {
@@ -22,31 +24,77 @@
   }
 
   [data-scope='splitter'][data-part='resize-trigger'] {
+    /* Component tokens (Tier 3) — public, semver-stable per-splitter override
+       surface. `handle-size` is the fixed grab-track thickness (the default
+       footprint, never animated → no reflow); `line-size` is the resting visible
+       line; `line-size-active` is the widened band on hover/drag. See
+       docs/styling.md. */
+    --manti-splitter-handle-size: 0.375rem;
+    --manti-splitter-line-size: 0.125rem;
+    --manti-splitter-line-size-active: 0.625rem;
+    /* Half the extra thickness, applied as an outline on each side of the line
+       so it grows outward without taking layout space. Derived → stays private. */
+    --_line-grow: calc(
+      (
+          var(--manti-splitter-line-size-active) -
+            var(--manti-splitter-line-size)
+        ) / 2
+    );
+
     flex: none;
+    position: relative;
+    z-index: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--manti-panel-border);
-    transition: background var(--manti-duration-fast) var(--manti-ease-smooth);
+    background: transparent;
+
+    /* The visible divider line. Thin at rest; widens via an outline of the same
+       tone on hover/drag, so the band can exceed the track and overlap the
+       panels without pushing them. */
+    &::before {
+      content: '';
+      display: block;
+      background: var(--manti-panel-border);
+      outline: 0 solid var(--tone-solid);
+      transition:
+        background-color var(--manti-duration-fast) var(--manti-ease-smooth),
+        outline-width var(--manti-duration-fast) var(--manti-ease-smooth);
+    }
 
     &[data-orientation='horizontal'] {
-      width: 0.375rem;
+      width: var(--manti-splitter-handle-size);
       cursor: col-resize;
+
+      &::before {
+        width: var(--manti-splitter-line-size);
+        height: 100%;
+      }
     }
 
     &[data-orientation='vertical'] {
-      height: 0.375rem;
+      height: var(--manti-splitter-handle-size);
       cursor: row-resize;
+
+      &::before {
+        width: 100%;
+        height: var(--manti-splitter-line-size);
+      }
     }
 
-    &:hover,
-    &[data-focus] {
+    /* Tone + widen on hover and during an active drag. Deliberately NOT keyed on
+       [data-focus]: after a mouse drag ends the machine keeps the trigger focused
+       (POINTER_UP → focused state), so a focus-based rule would leave the handle
+       stuck in the active tone. Keyboard focus is signalled by the ring below. */
+    &:hover::before,
+    &[data-dragging]::before {
       background: var(--tone-solid);
+      outline-width: var(--_line-grow);
     }
 
     &:focus-visible {
       outline: var(--manti-focus-ring-width) solid var(--tone-ring);
-      outline-offset: calc(var(--manti-focus-ring-offset) * -1);
+      outline-offset: var(--manti-focus-ring-offset);
     }
   }
 }

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -331,6 +331,7 @@ export const componentTokens = {
   'signature-pad': ['height'],
   slider: ['thumb-size', 'track-size', 'length'],
   spinner: ['size', 'thickness'],
+  splitter: ['handle-size', 'line-size', 'line-size-active'],
   steps: ['indicator-size'],
   switch: ['track-width', 'track-height', 'track-padding'],
   'tags-input': ['height'],


### PR DESCRIPTION
## What

Splitter resize-handle rework, released as **v0.1.4** (patch `.changeset` included; the four `@manti-ui/*` packages bump in lockstep once this reaches `main`).

### Changed — handle no longer reflows the panels
The resize trigger is now a **fixed-width grab track** holding a thin line (`::before`) that **tones and widens via an `outline`** on hover/drag, instead of animating the track's own width. Because the width stays constant, the panels don't shift when the handle grows.

The active state is keyed on `:hover` / `[data-dragging]` — deliberately **not** `[data-focus]`: after a mouse drag the Zag machine keeps the trigger focused, so a focus-based rule left the handle stuck in the active tone. Keyboard focus still shows the ring.

### Added — three Splitter component tokens
- `--manti-splitter-handle-size` — the grab-track thickness (the animated-free footprint)
- `--manti-splitter-line-size` — the resting visible line
- `--manti-splitter-line-size-active` — the widened band on hover/drag

Registered in `componentTokens` (`packages/tokens/src/index.ts`) and documented in `docs/component-tokens.md`; the derived half-grow stays a private `--_line-grow`.

## Release
- `.changeset/splitter-handle-tokens.md` (patch → **0.1.4** from 0.1.3).
- `packages/docs/src/content/changelog/v0-1-4.mdx` added; existing releases' `order` bumped so v0.1.4 sorts newest.

## Verification
- `pnpm verify` green (lint + typecheck + build); the styles build's `check-component-tokens.mjs` passes, so the CSS tokens match the registry.

Note: the in-progress `packages/cli/` + its `pnpm-lock.yaml` bump are intentionally **not** included here — separate CLI work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)