### PR TITLE
feat(color-picker): add eyedropper and format-tabs copy area

### DIFF
--- a/packages/docs/src/content/components/color-picker.mdx
+++ b/packages/docs/src/content/components/color-picker.mdx
@@ -9,9 +9,11 @@ description: A color picker with a saturation area, hue, and alpha, backed by th
 # ColorPicker
 
 A color picker backed by the Zag.js color-picker machine. The trigger shows the
-current swatch and value; opening it reveals a saturation area plus hue and alpha
-sliders and a hex input. Values are CSS color strings, so they drop straight into
-any context.
+current swatch and value; opening it reveals a saturation area, hue and alpha
+sliders, format tabs (hex/rgba/hsla) beside an eyedropper button for sampling a
+color from the screen, and a copyable Clipboard field showing the color in the
+selected format. Values are CSS color strings, so they drop straight into any
+context.
 
 <Demo name="color-picker/basic" center />
 

--- a/packages/docs/src/data/components/color-picker.ts
+++ b/packages/docs/src/data/components/color-picker.ts
@@ -85,6 +85,10 @@ export const meta: ComponentMeta = {
       part: 'transparency-grid',
       description: 'The checkerboard behind the alpha slider.',
     },
-    { part: 'channel-input', description: 'The hex text input.' },
+    {
+      part: 'copy-row',
+      description:
+        'Row holding the format tabs (a nested Manti Tabs) and the eyedropper Button; a Manti Clipboard below it shows the color in the selected format.',
+    },
   ],
 };

--- a/packages/react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.tsx
@@ -1,10 +1,13 @@
-import { useId, useMemo } from 'react';
+import { useId, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { colorPicker } from '@manti-ui/folds';
 import { normalizeProps, Portal, useMachine } from '@zag-js/react';
 
 import { cx } from '../../internal/props';
 import type { Placement } from '../../internal/floating';
+import { Button } from '../Button/Button';
+import { Clipboard } from '../Clipboard/Clipboard';
+import { Tabs } from '../Tabs/Tabs';
 
 export interface ColorPickerProps {
   /** Optional field label. */
@@ -29,6 +32,35 @@ export interface ColorPickerProps {
   id?: string;
   className?: string;
 }
+
+/** String formats the copy tabs expose. */
+const COPY_FORMATS = ['hex', 'rgba', 'hsla'] as const;
+
+type CopyFormat = (typeof COPY_FORMATS)[number];
+
+/** The tabs only drive the format selection — the full-width Clipboard below
+ * the row shows the value, so the tab panels stay empty (hidden via CSS). */
+const COPY_FORMAT_TABS = COPY_FORMATS.map((format) => ({
+  value: format,
+  label: format.toUpperCase(),
+  content: null,
+}));
+
+const eyeDropperIcon = (
+  <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+    <g
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m2 22 1-1h3l9-9" />
+      <path d="M3 21v-3l9-9" />
+      <path d="m15 6 3.4-3.4a2.1 2.1 0 1 1 3 3L18 9l.4.4a2.1 2.1 0 1 1-3 3l-3.8-3.8a2.1 2.1 0 1 1 3-3l.4.4Z" />
+    </g>
+  </svg>
+);
 
 /** A color picker backed by the Zag.js color-picker machine. */
 export function ColorPicker({
@@ -65,6 +97,8 @@ export function ColorPicker({
   });
   const api = colorPicker.connect(service, normalizeProps);
 
+  const [copyFormat, setCopyFormat] = useState<CopyFormat>('hex');
+
   return (
     <div {...api.getRootProps()} className={cx(className)}>
       {label != null && <label {...api.getLabelProps()}>{label}</label>}
@@ -86,16 +120,39 @@ export function ColorPicker({
               <div {...api.getAreaBackgroundProps()} />
               <div {...api.getAreaThumbProps()} />
             </div>
-            <div {...api.getChannelSliderProps({ channel: 'hue' })}>
-              <div {...api.getChannelSliderTrackProps({ channel: 'hue' })} />
-              <div {...api.getChannelSliderThumbProps({ channel: 'hue' })} />
+            <div data-part="sliders">
+              <div {...api.getChannelSliderProps({ channel: 'hue' })}>
+                <div {...api.getChannelSliderTrackProps({ channel: 'hue' })} />
+                <div {...api.getChannelSliderThumbProps({ channel: 'hue' })} />
+              </div>
+              <div {...api.getChannelSliderProps({ channel: 'alpha' })}>
+                <div {...api.getTransparencyGridProps()} />
+                <div
+                  {...api.getChannelSliderTrackProps({ channel: 'alpha' })}
+                />
+                <div
+                  {...api.getChannelSliderThumbProps({ channel: 'alpha' })}
+                />
+              </div>
             </div>
-            <div {...api.getChannelSliderProps({ channel: 'alpha' })}>
-              <div {...api.getTransparencyGridProps()} />
-              <div {...api.getChannelSliderTrackProps({ channel: 'alpha' })} />
-              <div {...api.getChannelSliderThumbProps({ channel: 'alpha' })} />
+            <div data-part="copy-row">
+              <Tabs
+                variant="soft"
+                size="sm"
+                items={COPY_FORMAT_TABS}
+                value={copyFormat}
+                onValueChange={(next) => setCopyFormat(next as CopyFormat)}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                iconOnly
+                {...api.getEyeDropperTriggerProps()}
+              >
+                {eyeDropperIcon}
+              </Button>
             </div>
-            <input {...api.getChannelInputProps({ channel: 'hex' })} />
+            <Clipboard value={api.value.toString(copyFormat)} />
           </div>
         </div>
       </Portal>

--- a/packages/styles/src/components/color-picker.css
+++ b/packages/styles/src/components/color-picker.css
@@ -1,7 +1,10 @@
 /**
  * Color Picker — backed by the Zag.js color-picker machine. The trigger shows a
- * live swatch; the portalled panel holds the saturation area, hue/alpha sliders,
- * and a hex input. The swatch background is user data, not a token.
+ * live swatch; the portalled panel holds the saturation area, hue/alpha
+ * sliders, and a copy area: a row of small Manti Tabs (hex/rgba/hsla) with the
+ * eyedropper Button beside them, over a full-width Manti Clipboard showing the
+ * color in the selected format. The swatch background is user data, not a
+ * token.
  */
 @layer manti.components {
   [data-scope='color-picker'][data-part='root'] {
@@ -113,6 +116,15 @@
     box-shadow: var(--manti-shadow-md);
   }
 
+  /* Custom wrapper: the hue/alpha channel sliders stacked as a column. */
+  [data-scope='color-picker'][data-part='content'] [data-part='sliders'] {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: var(--manti-space-3);
+    min-width: 0;
+  }
+
   [data-scope='color-picker'][data-part='channel-slider'] {
     position: relative;
     height: 0.75rem;
@@ -144,20 +156,29 @@
     border-radius: var(--manti-radius-full);
   }
 
-  [data-scope='color-picker'][data-part='channel-input'] {
-    min-width: 0;
-    padding: var(--manti-space-2) var(--manti-space-3);
-    background: var(--manti-surface-sunken);
-    border: 1px solid var(--manti-panel-border);
-    border-radius: var(--manti-radius-sm);
-    outline: none;
-    color: var(--manti-text);
-    font-size: var(--manti-text-sm);
-    font-family: var(--manti-font-mono);
-    text-transform: uppercase;
+  /* Custom row: the format tabs on the left, the eyedropper Button on the
+     right. The tabs only drive the selection — their panels stay empty and
+     hidden; the full-width Clipboard below the row shows the value. */
+  [data-scope='color-picker'][data-part='content'] [data-part='copy-row'] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--manti-space-2);
 
-    &:focus {
-      border-color: var(--tone-ring, var(--manti-focus-ring));
+    & [data-scope='tabs'][data-part='content'] {
+      display: none;
     }
+  }
+
+  /* The copy area embeds a Clipboard showing the color in the selected format.
+     The panel is narrow and the rgba/hsla strings are long, so compact the
+     field via the Clipboard's component tokens (its public Tier-3 override
+     surface). */
+  [data-scope='color-picker'][data-part='content']
+    [data-scope='clipboard'][data-part='control'] {
+    --manti-clipboard-height: var(--manti-control-height-sm);
+    --manti-clipboard-font-size: var(--manti-text-xs);
+    --manti-clipboard-padding-x: var(--manti-space-2);
+    --manti-clipboard-trigger-width: var(--manti-control-height-sm);
   }
 }


### PR DESCRIPTION
## Summary
- The picker panel gains a **copy area**: a `copy-row` with small `soft` Tabs (**HEX / RGBA / HSLA**) on the left and the **eyedropper** Button (outline/sm/iconOnly, wired via Zag's `getEyeDropperTriggerProps`) on the right, over a full-width **Clipboard** field showing `api.value.toString(format)` for the selected tab — one-click copy with the copied check indicator.
- The tabs only drive the format selection; their panels stay empty and are hidden with scoped CSS. One clipboard machine serves all formats, so the copied state survives tab switches.
- The embedded Clipboard is compacted through its public Tier-3 component tokens (`--manti-clipboard-height/font-size/padding-x/trigger-width`), scoped inside `[data-part='content']` — Clipboard's global look is untouched.
- The editable hex channel input is replaced by the Clipboard display (readonly, select-all on focus). Docs anatomy/MDX updated (`copy-row` part documented; `channel-input` removed).
- EyeDropper API note: Chromium-only; Zag no-ops the click on unsupported browsers.

**Stacked on #51** (`feat/tabs-size-sm` — the copy row uses `size="sm"`); best merged after #53 (clipboard border fix) for the intended focus visuals. Merge order: #50 → #51 → this (and #53 anytime before this for the intended focus visuals).

## Testing
- `pnpm verify` green.
- Headless Chrome (CDP, real pointer events): tab list and eyedropper share one row (button right of the list, empty tab panels `display: none`); switching to HSLA updates the field to `hsla(262.12, 83.26%, 57.84%, 1)` and the copy trigger writes exactly that string; the panel stays open throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
