### PR TITLE
fix(clipboard): keep focus border neutral, tint only when copied

### DIFF
--- a/packages/styles/src/components/clipboard.css
+++ b/packages/styles/src/components/clipboard.css
@@ -38,6 +38,13 @@
     box-shadow: inset 0 1px 0 0 var(--manti-panel-highlight);
 
     &:focus-within {
+      border-color: var(--manti-focus-ring);
+    }
+
+    /* The copied confirmation tints the whole field with the tone — focus
+       above stays neutral so plain clicks into the input don't read as
+       "copied". */
+    &[data-copied] {
       border-color: var(--tone-ring, var(--manti-focus-ring));
     }
   }


### PR DESCRIPTION
## Summary
- `:focus-within` on the Clipboard control used `--tone-ring` for its border. With the default `tone="success"` this meant simply clicking into the input turned the whole field green — indistinguishable from the copied confirmation.
- Focus now uses the neutral `--manti-focus-ring`; a new `&[data-copied]` rule (Zag sets `data-copied` on the control only during the copied timeout) tints the border with the tone ring, so green appears **only after the copy trigger is clicked** and reverts after the timeout.

## Testing
- `pnpm verify` green.
- Headless Chrome (computed `border-color`): idle `oklch(0.2 0.02 280 / 0.1)`, input focus `oklch(0.5 0.02 280)` (neutral), after copy `oklch(0.668 0.128 155)` (success ring), reverting after the 3s timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)