### PR TITLE
feat(checkbox): expose indicator-size component token

### DIFF
--- a/docs/component-tokens.md
+++ b/docs/component-tokens.md
@@ -52,6 +52,7 @@ component token only to make one component diverge on purpose — see
 | `checkbox`          | `--manti-checkbox-radius`                   | `var(--manti-radius-sm)`         |
 | `checkbox`          | `--manti-checkbox-gap`                      | `var(--manti-space-3)`           |
 | `checkbox`          | `--manti-checkbox-font-size`                | `var(--manti-text-sm)`           |
+| `checkbox`          | `--manti-checkbox-indicator-size`           | `80%`                            |
 | `clipboard`         | `--manti-clipboard-height`                  | `var(--manti-control-height-md)` |
 | `clipboard`         | `--manti-clipboard-radius`                  | `var(--manti-radius-md)`         |
 | `clipboard`         | `--manti-clipboard-padding-x`               | `var(--manti-space-3)`           |

--- a/packages/styles/src/components/checkbox.css
+++ b/packages/styles/src/components/checkbox.css
@@ -10,7 +10,7 @@
     --manti-checkbox-radius: var(--manti-radius-sm);
     --manti-checkbox-gap: var(--manti-space-3);
     --manti-checkbox-font-size: var(--manti-text-sm);
-
+    --manti-checkbox-indicator-size: 80%;
     display: inline-flex;
     align-items: center;
     gap: var(--manti-checkbox-gap);
@@ -19,10 +19,12 @@
 
     &[data-size='sm'] {
       --manti-checkbox-size: 1rem;
+      --manti-checkbox-indicator-size: 95%;
     }
 
     &[data-size='lg'] {
       --manti-checkbox-size: 1.5rem;
+      --manti-checkbox-indicator-size: 100%;
     }
 
     &[data-disabled] {
@@ -56,13 +58,11 @@
   [data-scope='checkbox'][data-part='indicator'] {
     display: grid;
     place-items: center;
-    width: 70%;
-    height: 70%;
+    width: var(--manti-checkbox-indicator-size);
+    height: var(--manti-checkbox-indicator-size);
   }
 
   [data-scope='checkbox'][data-part='indicator'] svg {
-    width: 100%;
-    height: 100%;
     stroke: currentColor;
     stroke-width: 3;
     stroke-linecap: round;

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -289,7 +289,7 @@ export const componentTokens = {
     'indicator-size',
     'viewport-height',
   ],
-  checkbox: ['size', 'radius', 'gap', 'font-size'],
+  checkbox: ['size', 'radius', 'gap', 'font-size', 'indicator-size'],
   clipboard: [
     'height',
     'radius',


### PR DESCRIPTION
## Summary
- New public Tier-3 component token `--manti-checkbox-indicator-size` controlling the check indicator's size inside the control: default `80%`, with per-size values (`95%` at `sm`, `100%` at `lg`) replacing the previous hard-coded `70%`.
- The indicator `svg` no longer sets its own `width/height: 100%` — it inherits the wrapper's grid sizing.
- Registered in the `componentTokens` contract; `docs/component-tokens.md` row added.

## Testing
- `pnpm verify` green (registry ↔ CSS ↔ generated-doc checks pass).
- Checked the Checkbox story visually in headless Chrome — the check icon renders correctly at the new sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)