### PR TITLE
feat(switch): squish the thumb while pressed

### DIFF
--- a/packages/styles/src/components/switch.css
+++ b/packages/styles/src/components/switch.css
@@ -34,6 +34,8 @@
   }
 
   [data-scope='switch'][data-part='control'] {
+    display: flex;
+    align-items: center;
     position: relative;
     flex: none;
     width: var(--manti-switch-track-width);
@@ -46,6 +48,10 @@
 
     &[data-state='checked'] {
       background: var(--tone-solid);
+    }
+    &:active [data-part='thumb'] {
+      transition: var(--manti-duration-base);
+      height: calc(var(--_thumb-size) - 0.25rem);
     }
   }
 


### PR DESCRIPTION
## Summary
- While the control is `:active`, the thumb's height shrinks by `0.25rem` (derived `calc()` off the private `--_thumb-size` knob) for a tactile press feel.
- The control becomes a centering flexbox (`display: flex; align-items: center`) so the squished thumb stays vertically centered instead of hanging from its top offset.
- Note: the original draft used a raw `transition: 200ms`; normalized to `var(--manti-duration-base)` (same 200ms) per the design-token rule.

## Testing
- `pnpm verify` green; Switch story checked visually in headless Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)