### PR TITLE
style(select): widen the states story grid

### DIFF
--- a/packages/react/src/components/Select/Select.stories.tsx
+++ b/packages/react/src/components/Select/Select.stories.tsx
@@ -47,7 +47,7 @@ export const Multiple: Story = {
 
 export const States: Story = {
   render: (args) => (
-    <div style={{ display: 'grid', gap: '1rem', width: 260 }}>
+    <div style={{ display: 'grid', gap: '1rem', width: 460 }}>
       <Select {...args} label="Default" />
       <Select {...args} label="Invalid" invalid />
       <Select {...args} label="Disabled" disabled />


### PR DESCRIPTION
## Summary
- Widens the `States` story grid from 260px to 460px so the default/invalid/disabled selects render at a more representative width in Storybook.

Story-only change; no component or CSS impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)