### PR TITLE
style(docs): shrink the theme toggle in the top nav

### DIFF
--- a/packages/docs/src/shell/TopNav.tsx
+++ b/packages/docs/src/shell/TopNav.tsx
@@ -77,6 +77,7 @@ export function TopNav() {
           variant="ghost"
           tone="primary"
           aria-label="Toggle dark theme"
+          size='sm'
           onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
         >
           {theme === 'dark' ? MoonIcon : SunIcon}


### PR DESCRIPTION
## Summary
- The docs header theme toggle becomes a `size="sm"` ghost button so it sits better against the rest of the top-nav controls.

Docs-site-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)