### PR TITLE
chore(release): changesets for v0.1.5 (tabs + clipboard fixes)

### DIFF
--- a/.changeset/clipboard-neutral-focus-border.md
+++ b/.changeset/clipboard-neutral-focus-border.md
@@ -1,0 +1,7 @@
+---
+'@manti-ui/styles': patch
+---
+
+fix(clipboard): keep the focus border neutral, tint only when copied (#53)
+
+`:focus-within` used `--tone-ring` for the control border, so with the default `tone="success"` simply focusing the field turned it green — indistinguishable from the copied confirmation. Focus now uses the neutral `--manti-focus-ring`, and a new `&[data-copied]` rule applies the tone ring only during the copied timeout.

--- a/.changeset/tabs-list-direct-child-scoping.md
+++ b/.changeset/tabs-list-direct-child-scoping.md
@@ -1,0 +1,7 @@
+---
+'@manti-ui/styles': patch
+---
+
+fix(tabs): scope trigger/indicator styles to the list's direct children (#50)
+
+Tabs variant rules matched any descendant `[data-part='trigger']`/`[data-part='indicator']` under the root, so components rendered inside tab content (e.g. a Clipboard's icon wrappers) leaked the sliding-thumb chrome. Both parts are now anchored through `> [data-part='list'] >`, leaving embedded components untouched with no visual change to the tabs themselves.


### PR DESCRIPTION
Adds the two patch changesets for fixes already merged to `dev`/`main` without one, so the release workflow can cut **v0.1.5**.

- fix(tabs): scope trigger/indicator styles to the list's direct children (#50)
- fix(clipboard): keep focus border neutral, tint only when copied (#53)

Both fixes touch only `@manti-ui/styles`; the `fixed` group bumps all four `@manti-ui/*` packages to **0.1.5** in lockstep.

## Release path after merge
1. Merge this into `dev`.
2. Merge `dev` → `main`.
3. The Release workflow opens a **"chore(release): version packages"** PR (bumps versions + writes CHANGELOGs).
4. Merge that PR → publishes to npm and cuts the `v0.1.5` GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)