### PR TITLE
docs(changelog): v0.1.5 release notes

### DIFF
--- a/packages/docs/src/content/changelog/v0-1-0.mdx
+++ b/packages/docs/src/content/changelog/v0-1-0.mdx
@@ -2,7 +2,7 @@
 title: v0.1.0
 slug: /changelog/v0.1.0
 group: Changelog
-order: 5
+order: 6
 date: '2026-06-23'
 description: The first public release of Manti UI.
 ---

--- a/packages/docs/src/content/changelog/v0-1-1.mdx
+++ b/packages/docs/src/content/changelog/v0-1-1.mdx
@@ -2,7 +2,7 @@
 title: v0.1.1
 slug: /changelog/v0.1.1
 group: Changelog
-order: 4
+order: 5
 date: '2026-06-26'
 description: A TanStack-backed DataTable, a categorized and collapsible docs sidebar, the panel token rename, scrollable Combobox and Select listboxes, a Carousel slide-gap token, and overlay fixes.
 ---

--- a/packages/docs/src/content/changelog/v0-1-2.mdx
+++ b/packages/docs/src/content/changelog/v0-1-2.mdx
@@ -2,7 +2,7 @@
 title: v0.1.2
 slug: /changelog/v0.1.2
 group: Changelog
-order: 3
+order: 4
 date: '2026-06-29'
 description: A new Textarea multiline field, per-node TreeView icons, scrollable TimePicker columns, a tonal Listbox selection, and Combobox and TagsInput refinements.
 ---

--- a/packages/docs/src/content/changelog/v0-1-3.mdx
+++ b/packages/docs/src/content/changelog/v0-1-3.mdx
@@ -2,7 +2,7 @@
 title: v0.1.3
 slug: /changelog/v0.1.3
 group: Changelog
-order: 2
+order: 3
 date: '2026-07-01'
 description: A centered ColorPicker slider thumb and an optional swatch-only trigger.
 ---

--- a/packages/docs/src/content/changelog/v0-1-4.mdx
+++ b/packages/docs/src/content/changelog/v0-1-4.mdx
@@ -2,7 +2,7 @@
 title: v0.1.4
 slug: /changelog/v0.1.4
 group: Changelog
-order: 1
+order: 2
 date: '2026-07-01'
 description: A reworked Splitter resize handle that widens without reflowing panels, plus three Splitter component tokens.
 ---

--- a/packages/docs/src/content/changelog/v0-1-5.mdx
+++ b/packages/docs/src/content/changelog/v0-1-5.mdx
@@ -1,0 +1,26 @@
+---
+title: v0.1.5
+slug: /changelog/v0.1.5
+group: Changelog
+order: 1
+date: '2026-07-03'
+description: Two fixes — Tabs no longer leak their trigger/indicator chrome onto components embedded in tab content, and the Clipboard control keeps a neutral focus border, tinting only once copied.
+---
+
+# v0.1.5
+
+_Released 2026-07-03._
+
+## Fixed
+
+- **Tabs** — variant rules for the `trigger` and `indicator` parts matched any
+  descendant under the root, so components rendered inside tab content (for
+  example a Clipboard's copy/check icon wrappers, which are `indicator` parts)
+  picked up the sliding-thumb chrome and rendered as a stray box. Both parts are
+  now anchored through `> [data-part='list'] >`, so only the tabs' own anatomy is
+  styled and embedded components are left alone. No visual change to the tabs.
+- **Clipboard** — `:focus-within` used the tone ring for its border, so with the
+  default `tone="success"` simply clicking into the field turned it green,
+  indistinguishable from the copied confirmation. Focus now uses the neutral
+  `--manti-focus-ring`, and the tone tint applies only while `data-copied` is set
+  (during the copied timeout).


### PR DESCRIPTION
Adds the docs-site changelog entry for **v0.1.5** (already published to npm) and shifts existing entries' `order` so the list stays newest-first.

## v0.1.5 — *Fixed*
- Tabs: scope trigger/indicator styles to the list's direct children (#50)
- Clipboard: neutral focus border, tint only when copied (#53)

Docs-only (`packages/docs`, private) — no changeset, does not trigger an npm release. Landing this fixes the "what's new" badge 404 for v0.1.5.

> **Note:** the **v0.2.0** changelog entry was intentionally removed from this PR — it ships together with the v0.2.0 release (added alongside the minor changeset) so the docs site never advertises a version before it's on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)