### PR TITLE
chore(release): version packages to 0.3.0

### DIFF
--- a/packages/docs/src/content/changelog/v0-1-0.mdx
+++ b/packages/docs/src/content/changelog/v0-1-0.mdx
@@ -2,7 +2,7 @@
 title: v0.1.0
 slug: /changelog/v0.1.0
 group: Changelog
-order: 7
+order: 8
 date: '2026-06-23'
 description: The first public release of Manti UI — the design-token contract, the monochrome design signature, and the initial component set, published to npm.
 ---

--- a/packages/docs/src/content/changelog/v0-1-1.mdx
+++ b/packages/docs/src/content/changelog/v0-1-1.mdx
@@ -2,7 +2,7 @@
 title: v0.1.1
 slug: /changelog/v0.1.1
 group: Changelog
-order: 6
+order: 7
 date: '2026-06-26'
 description: A TanStack-backed DataTable, a categorized collapsible docs sidebar, the panel token rename, scrollable Combobox and Select listboxes, and overlay fixes.
 ---

--- a/packages/docs/src/content/changelog/v0-1-2.mdx
+++ b/packages/docs/src/content/changelog/v0-1-2.mdx
@@ -2,7 +2,7 @@
 title: v0.1.2
 slug: /changelog/v0.1.2
 group: Changelog
-order: 5
+order: 6
 date: '2026-06-29'
 description: A new Textarea multiline field, per-node TreeView icons, scrollable TimePicker columns, a tonal Listbox selection, and Combobox and TagsInput refinements.
 ---

--- a/packages/docs/src/content/changelog/v0-1-3.mdx
+++ b/packages/docs/src/content/changelog/v0-1-3.mdx
@@ -2,7 +2,7 @@
 title: v0.1.3
 slug: /changelog/v0.1.3
 group: Changelog
-order: 4
+order: 5
 date: '2026-07-01'
 description: A centered ColorPicker slider thumb and an optional swatch-only trigger.
 ---

--- a/packages/docs/src/content/changelog/v0-1-4.mdx
+++ b/packages/docs/src/content/changelog/v0-1-4.mdx
@@ -2,7 +2,7 @@
 title: v0.1.4
 slug: /changelog/v0.1.4
 group: Changelog
-order: 3
+order: 4
 date: '2026-07-01'
 description: A reworked Splitter resize handle that widens without reflowing panels, plus three Splitter component tokens.
 ---

--- a/packages/docs/src/content/changelog/v0-1-5.mdx
+++ b/packages/docs/src/content/changelog/v0-1-5.mdx
@@ -2,7 +2,7 @@
 title: v0.1.5
 slug: /changelog/v0.1.5
 group: Changelog
-order: 2
+order: 3
 date: '2026-07-03'
 description: 'Two fixes: Tabs no longer leak trigger and indicator styles into embedded components, and Clipboard keeps a neutral focus border until a copy succeeds.'
 ---

--- a/packages/docs/src/content/changelog/v0-2-0.mdx
+++ b/packages/docs/src/content/changelog/v0-2-0.mdx
@@ -2,7 +2,7 @@
 title: v0.2.0
 slug: /changelog/v0.2.0
 group: Changelog
-order: 1
+order: 2
 date: '2026-07-04'
 description: A month-grid Calendar, a ColorPicker copy area with eyedropper and format tabs, a compact Tabs size, new Button and Checkbox tokens, and two anatomy changes.
 ---

--- a/packages/docs/src/content/changelog/v0-3-0.mdx
+++ b/packages/docs/src/content/changelog/v0-3-0.mdx
@@ -1,0 +1,32 @@
+---
+title: v0.3.0
+slug: /changelog/v0.3.0
+group: Changelog
+order: 1
+date: '2026-07-13'
+description: A framework-agnostic keyboard-shortcut primitive — useShortcut / useShortcuts — bindable to any component, plus a softer Button soft-variant highlight.
+---
+
+# v0.3.0
+
+_Released 2026-07-13._
+
+## Added
+
+- **useShortcut** — a new framework-agnostic keyboard-shortcut primitive.
+  `useShortcut(combo, handler, options)` and `useShortcuts(map, options)` bind
+  key combinations to actions on **any** component — Manti UI or your own. It
+  supports modifier combos (`mod+k`, `ctrl+shift+p`, where `mod` resolves to ⌘
+  on macOS and Ctrl elsewhere) and key **sequences** (`g d`). Global by default
+  (listens on `window`, so it fires regardless of focus with zero wiring) or
+  scoped to a `ref`. Includes a form-element guard (won't fire while you type in
+  an input/textarea/contenteditable unless `enableOnFormElements` is set),
+  `preventDefault` on by default, plus `stopPropagation` and `enabled`. It is
+  SSR-safe and backed by a pure-DOM engine in `@manti-ui/folds`, and is exposed
+  standalone at `@manti-ui/react/shortcut` so it can be imported without pulling
+  in any Manti UI component.
+
+## Changed
+
+- **Button** — the `soft` variant's panel highlight is now a subtle inset glow
+  rather than a top highlight line, for a softer raised feel.

--- a/packages/folds/package.json
+++ b/packages/folds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/folds",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Framework-agnostic Zag.js behavior contracts for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React adapter for the Manti UI design system.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/styles",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Framework-agnostic CSS for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/tokens",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Framework-agnostic design token contract for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",


### PR DESCRIPTION
Cuts the **0.3.0** release. Manual version bump of the `fixed` group — **not** `changeset version`, which would jump a 0.x `minor` straight to 1.0.0.

## Version bump (0.2.0 → 0.3.0)
- `@manti-ui/tokens`
- `@manti-ui/styles`
- `@manti-ui/folds`
- `@manti-ui/react`

(`@manti-ui/docs` is private and `@manti-ui/cli` is out of the fixed group — neither bumps.)

## What's in 0.3.0
- **Added:** `useShortcut` / `useShortcuts` — a framework-agnostic keyboard-shortcut primitive (#35), also exposed standalone at `@manti-ui/react/shortcut`.
- **Changed:** Button `soft`-variant highlight softened to an inset glow.

## Changelog
- New `packages/docs/src/content/changelog/v0-3-0.mdx` (slug `/changelog/v0.3.0`, so the header "what's new" badge — which links to `/changelog/v${version}` — resolves after the bump).
- Older release `order` values cascaded +1 so the list stays newest-first.

## Verification
- `pnpm verify` green (lint + typecheck + build + Storybook).
- Docs build green; `/changelog/v0.3.0` prerendered and the header badge links to it.
- Lockfile intentionally untouched (workspace version bumps use `link:` refs; no lock change).

## Publish flow (after this merges)
Merging **dev → main** triggers `release.yml`: with no changeset files but versions ahead of npm, the changesets action runs `publish`, then tags **`v0.3.0`** and cuts the GitHub Release. I'll confirm before that dev→main merge, since npm publish is irreversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)