### PR TITLE
Release v0.3.0

### DIFF
--- a/packages/docs/src/content/changelog/v0-1-0.mdx
+++ b/packages/docs/src/content/changelog/v0-1-0.mdx
@@ -2,7 +2,7 @@
 title: v0.1.0
 slug: /changelog/v0.1.0
 group: Changelog
-order: 7
+order: 8
 date: '2026-06-23'
 description: The first public release of Manti UI — the design-token contract, the monochrome design signature, and the initial component set, published to npm.
 ---

--- a/packages/docs/src/content/changelog/v0-1-1.mdx
+++ b/packages/docs/src/content/changelog/v0-1-1.mdx
@@ -2,7 +2,7 @@
 title: v0.1.1
 slug: /changelog/v0.1.1
 group: Changelog
-order: 6
+order: 7
 date: '2026-06-26'
 description: A TanStack-backed DataTable, a categorized collapsible docs sidebar, the panel token rename, scrollable Combobox and Select listboxes, and overlay fixes.
 ---

--- a/packages/docs/src/content/changelog/v0-1-2.mdx
+++ b/packages/docs/src/content/changelog/v0-1-2.mdx
@@ -2,7 +2,7 @@
 title: v0.1.2
 slug: /changelog/v0.1.2
 group: Changelog
-order: 5
+order: 6
 date: '2026-06-29'
 description: A new Textarea multiline field, per-node TreeView icons, scrollable TimePicker columns, a tonal Listbox selection, and Combobox and TagsInput refinements.
 ---

--- a/packages/docs/src/content/changelog/v0-1-3.mdx
+++ b/packages/docs/src/content/changelog/v0-1-3.mdx
@@ -2,7 +2,7 @@
 title: v0.1.3
 slug: /changelog/v0.1.3
 group: Changelog
-order: 4
+order: 5
 date: '2026-07-01'
 description: A centered ColorPicker slider thumb and an optional swatch-only trigger.
 ---

--- a/packages/docs/src/content/changelog/v0-1-4.mdx
+++ b/packages/docs/src/content/changelog/v0-1-4.mdx
@@ -2,7 +2,7 @@
 title: v0.1.4
 slug: /changelog/v0.1.4
 group: Changelog
-order: 3
+order: 4
 date: '2026-07-01'
 description: A reworked Splitter resize handle that widens without reflowing panels, plus three Splitter component tokens.
 ---

--- a/packages/docs/src/content/changelog/v0-1-5.mdx
+++ b/packages/docs/src/content/changelog/v0-1-5.mdx
@@ -2,7 +2,7 @@
 title: v0.1.5
 slug: /changelog/v0.1.5
 group: Changelog
-order: 2
+order: 3
 date: '2026-07-03'
 description: 'Two fixes: Tabs no longer leak trigger and indicator styles into embedded components, and Clipboard keeps a neutral focus border until a copy succeeds.'
 ---

--- a/packages/docs/src/content/changelog/v0-2-0.mdx
+++ b/packages/docs/src/content/changelog/v0-2-0.mdx
@@ -2,7 +2,7 @@
 title: v0.2.0
 slug: /changelog/v0.2.0
 group: Changelog
-order: 1
+order: 2
 date: '2026-07-04'
 description: A month-grid Calendar, a ColorPicker copy area with eyedropper and format tabs, a compact Tabs size, new Button and Checkbox tokens, and two anatomy changes.
 ---

--- a/packages/docs/src/content/changelog/v0-3-0.mdx
+++ b/packages/docs/src/content/changelog/v0-3-0.mdx
@@ -1,0 +1,32 @@
+---
+title: v0.3.0
+slug: /changelog/v0.3.0
+group: Changelog
+order: 1
+date: '2026-07-13'
+description: A framework-agnostic keyboard-shortcut primitive — useShortcut / useShortcuts — bindable to any component, plus a softer Button soft-variant highlight.
+---
+
+# v0.3.0
+
+_Released 2026-07-13._
+
+## Added
+
+- **useShortcut** — a new framework-agnostic keyboard-shortcut primitive.
+  `useShortcut(combo, handler, options)` and `useShortcuts(map, options)` bind
+  key combinations to actions on **any** component — Manti UI or your own. It
+  supports modifier combos (`mod+k`, `ctrl+shift+p`, where `mod` resolves to ⌘
+  on macOS and Ctrl elsewhere) and key **sequences** (`g d`). Global by default
+  (listens on `window`, so it fires regardless of focus with zero wiring) or
+  scoped to a `ref`. Includes a form-element guard (won't fire while you type in
+  an input/textarea/contenteditable unless `enableOnFormElements` is set),
+  `preventDefault` on by default, plus `stopPropagation` and `enabled`. It is
+  SSR-safe and backed by a pure-DOM engine in `@manti-ui/folds`, and is exposed
+  standalone at `@manti-ui/react/shortcut` so it can be imported without pulling
+  in any Manti UI component.
+
+## Changed
+
+- **Button** — the `soft` variant's panel highlight is now a subtle inset glow
+  rather than a top highlight line, for a softer raised feel.

--- a/packages/docs/src/content/utilities/use-shortcut.mdx
+++ b/packages/docs/src/content/utilities/use-shortcut.mdx
@@ -1,0 +1,108 @@
+---
+title: useShortcut
+slug: /utilities/use-shortcut
+group: Utilities
+order: 60
+badge: New
+description: A framework-agnostic keyboard-shortcut hook — bind combos and sequences to any component, globally or scoped to a region.
+---
+
+# useShortcut
+
+Bind keyboard combinations to actions on **any** component — Manti UI or your
+own. `useShortcut` is a standalone primitive: a single call is enough to wire a
+global shortcut, with an opt-in scoped mode for shortcuts that should only fire
+inside a region.
+
+It is backed by the framework-agnostic shortcut engine in `@manti-ui/folds`
+(like [Swipe](/components/swipe), it is not a Zag.js machine), so the same core
+can power future Vue/Svelte/Solid renderers and any plain-JS consumer.
+
+<Demo name="shortcut/global" center />
+
+> The search field in this site's header is powered by exactly this hook —
+> `useShortcut('mod+k', () => setOpen(true))`.
+
+## Import
+
+`useShortcut` and `useShortcuts` ship from a dedicated subpath, so you can pull
+in just the hook without loading any Manti UI component:
+
+```tsx
+import { useShortcut, useShortcuts } from '@manti-ui/react/shortcut';
+```
+
+They are also re-exported from the package root (`@manti-ui/react`) for
+convenience.
+
+## Scoped to a region
+
+Pass a `ref` as the `scope` and the combo only fires while focus is inside that
+element — no Manti component required, any element that forwards a ref works.
+Elsewhere on the page the same combo falls through to the browser.
+
+<Demo name="shortcut/scoped" center />
+
+## Multiple shortcuts
+
+`useShortcuts` binds a whole map at once. Combos can be single presses
+(`mod+b`) or **sequences** — press `g` then `d` for `g d`.
+
+<Demo name="shortcut/multiple" center />
+
+## Typing in inputs
+
+By default a combo does **not** fire while focus is in an `input`, `textarea`,
+`select`, or `contenteditable` region, so shortcuts never hijack what someone is
+typing. Opt a binding back in with `enableOnFormElements`.
+
+<Demo name="shortcut/form-guard" center />
+
+## Combo syntax
+
+| Kind          | Example         | Notes                                                     |
+| ------------- | --------------- | --------------------------------------------------------- |
+| Modifier      | `mod+k`         | `mod` resolves to ⌘ on macOS and Ctrl everywhere else.    |
+| Modifiers     | `ctrl+shift+p`  | Combine `ctrl`, `shift`, `alt`/`option`, `meta`/`cmd`.    |
+| Single key    | `escape`, `/`   | Named keys (`enter`, `escape`, `space`, arrows) or a char.|
+| Sequence      | `g d`           | Space-separated steps, pressed in order within a second.  |
+
+Modifier matching is exact — `mod+k` fires on ⌘K but not on ⌘⇧K.
+
+## API
+
+```ts
+useShortcut(
+  combo: string,
+  handler: (event: KeyboardEvent) => void,
+  options?: ShortcutOptions,
+): void
+
+useShortcuts(
+  map: Record<string, (event: KeyboardEvent) => void>,
+  options?: ShortcutOptions,
+): void
+```
+
+### Options
+
+| Option                 | Type                     | Default    | Description                                                                 |
+| ---------------------- | ------------------------ | ---------- | --------------------------------------------------------------------------- |
+| `scope`                | `'global' \| RefObject`  | `'global'` | `'global'` listens on `window`; a ref scopes firing to that element's subtree. |
+| `preventDefault`       | `boolean`                | `true`     | Calls `event.preventDefault()` so combos like ⌘R/⌘S/⌘P/⌘F skip their native action. |
+| `enabled`              | `boolean`                | `true`     | Toggle the binding without unmounting.                                      |
+| `enableOnFormElements` | `boolean`                | `false`    | Allow firing while focus is in an input/textarea/contenteditable.           |
+| `stopPropagation`      | `boolean`                | `false`    | Also call `event.stopPropagation()` on match.                               |
+| `sequenceTimeout`      | `number`                 | `1000`     | How long (ms) a sequence like `g d` may pause between steps before it resets. |
+
+## Why it works on any component
+
+The hook never wraps or modifies the target — it only registers a handler:
+
+- **Global (default):** the listener is on `window`, so it fires regardless of
+  focus and needs zero wiring on the target. Works for any custom component.
+- **Scoped:** pass a `ref` to your component's root; it fires only when focus is
+  inside it. Works on any element that forwards a ref.
+
+It is also **SSR-safe**: nothing touches `window` at module load — the listener
+is attached inside an effect, on the client only.

--- a/packages/docs/src/data/navigation.ts
+++ b/packages/docs/src/data/navigation.ts
@@ -29,6 +29,10 @@ const GROUP_ORDER = [
   'Getting Started',
   'Foundations',
   'Guides',
+  // Framework-agnostic primitives that aren't visual components (hooks like
+  // useShortcut), each its own page ordered by `order`. Sits above the component
+  // sections.
+  'Utilities',
   // The `/components` overview sits alone in its "Components" group, above the
   // categorized component sections.
   'Components',

--- a/packages/docs/src/demos/shortcut/form-guard.tsx
+++ b/packages/docs/src/demos/shortcut/form-guard.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { Badge, TextField } from '@manti-ui/react';
+import { useShortcut } from '@manti-ui/react/shortcut';
+
+export default function ShortcutFormGuard() {
+  const [count, setCount] = useState(0);
+
+  // By default a combo won't fire while you type in an input/textarea. Set
+  // `enableOnFormElements` to opt in — here ⌘Enter submits from inside the field.
+  useShortcut('mod+enter', () => setCount((n) => n + 1), {
+    enableOnFormElements: true,
+  });
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: 'var(--manti-space-3)',
+        width: 'calc(var(--manti-space-16) * 4)',
+      }}
+    >
+      <TextField
+        label="Comment"
+        placeholder="Type, then press ⌘/Ctrl+Enter to submit"
+      />
+      <Badge tone={count > 0 ? 'success' : 'neutral'}>Submitted ×{count}</Badge>
+    </div>
+  );
+}

--- a/packages/docs/src/demos/shortcut/global.tsx
+++ b/packages/docs/src/demos/shortcut/global.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { Badge, Button, Dialog, TextField } from '@manti-ui/react';
+import { useShortcut } from '@manti-ui/react/shortcut';
+
+export default function ShortcutGlobal() {
+  const [open, setOpen] = useState(false);
+
+  // Global by default: the listener sits on `window`, so the combo fires
+  // regardless of focus and needs zero wiring on any element. `preventDefault`
+  // is on by default, so the browser's own combo doesn't also fire.
+  useShortcut('mod+i', () => setOpen(true));
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--manti-space-3)',
+      }}
+    >
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <Badge variant="outline" style={{ fontFamily: 'var(--manti-font-mono)' }}>
+        mod+i
+      </Badge>
+      <Dialog
+        open={open}
+        onOpenChange={setOpen}
+        title="Quick open"
+        description="Opened by click or by the global ⌘I / Ctrl+I shortcut."
+      >
+        <TextField label="Search" placeholder="Type to search…" />
+      </Dialog>
+    </div>
+  );
+}

--- a/packages/docs/src/demos/shortcut/multiple.tsx
+++ b/packages/docs/src/demos/shortcut/multiple.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { Badge, Card } from '@manti-ui/react';
+import { useShortcuts } from '@manti-ui/react/shortcut';
+
+const COMBOS = ['mod+b', 'mod+/', 'g d'];
+
+export default function ShortcutMultiple() {
+  const [log, setLog] = useState<string[]>([]);
+  const push = (message: string) =>
+    setLog((prev) => [message, ...prev].slice(0, 4));
+
+  // Bind several combos at once. `g d` is a sequence: press `g` then `d`.
+  useShortcuts({
+    'mod+b': () => push('mod+b → bold'),
+    'mod+/': () => push('mod+/ → toggle help'),
+    'g d': () => push('g d → go to dashboard'),
+  });
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: 'var(--manti-space-3)',
+        width: 'calc(var(--manti-space-16) * 4)',
+      }}
+    >
+      <div
+        style={{ display: 'flex', gap: 'var(--manti-space-2)', flexWrap: 'wrap' }}
+      >
+        {COMBOS.map((combo) => (
+          <Badge
+            key={combo}
+            variant="outline"
+            style={{ fontFamily: 'var(--manti-font-mono)' }}
+          >
+            {combo}
+          </Badge>
+        ))}
+      </div>
+      <Card
+        style={{
+          display: 'grid',
+          gap: 'var(--manti-space-1)',
+          padding: 'var(--manti-space-4)',
+          minHeight: 'calc(var(--manti-space-16) * 1.5)',
+        }}
+      >
+        {log.length === 0 ? (
+          <span style={{ color: 'var(--manti-text-muted)' }}>
+            Press a shortcut…
+          </span>
+        ) : (
+          log.map((entry, index) => (
+            <span
+              key={`${entry}-${index}`}
+              style={{
+                fontFamily: 'var(--manti-font-mono)',
+                opacity: index === 0 ? 1 : 0.5,
+              }}
+            >
+              {entry}
+            </span>
+          ))
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/packages/docs/src/demos/shortcut/scoped.tsx
+++ b/packages/docs/src/demos/shortcut/scoped.tsx
@@ -1,0 +1,35 @@
+import { useRef, useState } from 'react';
+import { Badge, Card } from '@manti-ui/react';
+import { useShortcut } from '@manti-ui/react/shortcut';
+
+export default function ShortcutScoped() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [saves, setSaves] = useState(0);
+
+  // Scoped: pass a ref and the combo only fires while focus is inside it. ⌘S
+  // outside the region falls through to the browser; `preventDefault` stops the
+  // native "save page" dialog when it does fire here.
+  useShortcut('mod+s', () => setSaves((n) => n + 1), { scope: ref });
+
+  return (
+    <div ref={ref} tabIndex={-1} style={{ outline: 'none' }}>
+      <Card
+        elevated
+        style={{
+          display: 'grid',
+          gap: 'var(--manti-space-3)',
+          padding: 'var(--manti-space-5)',
+          width: 'calc(var(--manti-space-16) * 4)',
+        }}
+      >
+        <strong>Editor region</strong>
+        <span style={{ color: 'var(--manti-text-muted)' }}>
+          Click to focus, then press ⌘S / Ctrl+S to save.
+        </span>
+        <Badge tone={saves > 0 ? 'success' : 'neutral'}>
+          {saves > 0 ? `Saved ×${saves}` : 'Not saved'}
+        </Badge>
+      </Card>
+    </div>
+  );
+}

--- a/packages/docs/src/mdx/MDXComponents.tsx
+++ b/packages/docs/src/mdx/MDXComponents.tsx
@@ -35,11 +35,14 @@ function Anchor({ href = '', children, ...rest }: ComponentProps<'a'>) {
   );
 }
 
-// `@manti-ui/react` also exports a metadata object and a toaster factory; neither
-// is a renderable component, so drop them before spreading into the MDX map.
+// `@manti-ui/react` also exports a metadata object, a toaster factory and the
+// shortcut hooks; none is a renderable component, so drop them before spreading
+// into the MDX map.
 const {
   mantiUi: _mantiUi,
   createToaster: _createToaster,
+  useShortcut: _useShortcut,
+  useShortcuts: _useShortcuts,
   ...mantiComponents
 } = Manti;
 

--- a/packages/docs/src/search/SearchProvider.tsx
+++ b/packages/docs/src/search/SearchProvider.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
+import { useShortcut } from '@manti-ui/react/shortcut';
 import MiniSearch from 'minisearch';
 
 import searchDocs from 'virtual:manti-search';
@@ -40,16 +41,9 @@ export function searchDocsByQuery(query: string, limit = 8): SearchHit[] {
 export function SearchProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false);
 
-  useEffect(() => {
-    function onKey(event: KeyboardEvent) {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
-        event.preventDefault();
-        setOpen((value) => !value);
-      }
-    }
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, []);
+  // ⌘K / Ctrl+K toggles search from anywhere (preventDefault is on by default,
+  // so the browser's own ⌘K doesn't also fire). See @manti-ui/react/shortcut.
+  useShortcut('mod+k', () => setOpen((value) => !value));
 
   const value = useMemo(() => ({ open, setOpen }), [open]);
   return (

--- a/packages/folds/package.json
+++ b/packages/folds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/folds",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Framework-agnostic Zag.js behavior contracts for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/folds/src/index.ts
+++ b/packages/folds/src/index.ts
@@ -47,6 +47,13 @@ export * as floatingPanel from '@zag-js/floating-panel';
 export * as swipe from './swipe';
 
 /**
+ * Keyboard-shortcut engine. Also a Manti-original (Zag has no shortcut machine):
+ * a pure-DOM controller that binds key combos/sequences to handlers, reusable by
+ * any renderer or plain JS consumer. The React layer wraps it in `useShortcut`.
+ */
+export * as shortcut from './shortcut';
+
+/**
  * Headless data behaviors. Not from Zag.js — Zag has no table machine, so the
  * Data Table is built on TanStack `table-core`, the same headless/agnostic shape
  * (logic-only brain + per-framework adapter). The shared column/types contract

--- a/packages/folds/src/shortcut/index.ts
+++ b/packages/folds/src/shortcut/index.ts
@@ -1,0 +1,2 @@
+export * from './shortcut.types';
+export * from './shortcut.core';

--- a/packages/folds/src/shortcut/shortcut.core.ts
+++ b/packages/folds/src/shortcut/shortcut.core.ts
@@ -1,0 +1,216 @@
+import type {
+  ShortcutBinding,
+  ShortcutControl,
+  ShortcutOptions,
+  ShortcutStep,
+  ShortcutTarget,
+} from './shortcut.types';
+
+const DEFAULT_SEQUENCE_TIMEOUT = 1000;
+
+// The most steps any single combo can span, which also caps the recent-key
+// buffer — no realistic sequence is longer, and it bounds memory.
+const MAX_SEQUENCE_LENGTH = 8;
+
+/** Aliases mapped onto a single canonical key token (both sides normalized). */
+const KEY_ALIASES: Record<string, string> = {
+  ' ': 'space',
+  spacebar: 'space',
+  esc: 'escape',
+  return: 'enter',
+  del: 'delete',
+  up: 'arrowup',
+  down: 'arrowdown',
+  left: 'arrowleft',
+  right: 'arrowright',
+  plus: '+',
+};
+
+/** Modifier key names, so a lone modifier keydown can be ignored. */
+const MODIFIER_KEYS = new Set(['control', 'meta', 'shift', 'alt']);
+
+/** Normalize a raw key token (from a combo or `event.key`) to a canonical form. */
+function canonicalKey(raw: string): string {
+  const key = raw.toLowerCase();
+  return KEY_ALIASES[key] ?? key;
+}
+
+/** Detect macOS-family platforms so `mod` resolves to ⌘ instead of Ctrl. */
+function detectMac(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const platform =
+    // `userAgentData` is the modern source; `platform`/`userAgent` are fallbacks.
+    (navigator as Navigator & { userAgentData?: { platform?: string } })
+      .userAgentData?.platform ||
+    navigator.platform ||
+    navigator.userAgent ||
+    '';
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
+/**
+ * Parse a combo string into its ordered steps. `mod` resolves to ⌘ (`meta`) on
+ * macOS and Ctrl elsewhere; unknown tokens become the step's key.
+ */
+export function parseCombo(combo: string, mac: boolean): ShortcutStep[] {
+  return combo
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((stepText) => {
+      const step: ShortcutStep = {
+        ctrl: false,
+        meta: false,
+        shift: false,
+        alt: false,
+        key: '',
+      };
+      for (const rawToken of stepText.split('+')) {
+        const token = rawToken.trim().toLowerCase();
+        if (!token) continue;
+        switch (token) {
+          case 'mod':
+            if (mac) step.meta = true;
+            else step.ctrl = true;
+            break;
+          case 'ctrl':
+          case 'control':
+            step.ctrl = true;
+            break;
+          case 'meta':
+          case 'cmd':
+          case 'command':
+          case 'super':
+          case 'win':
+            step.meta = true;
+            break;
+          case 'shift':
+            step.shift = true;
+            break;
+          case 'alt':
+          case 'option':
+          case 'opt':
+            step.alt = true;
+            break;
+          default:
+            step.key = canonicalKey(token);
+        }
+      }
+      return step;
+    });
+}
+
+/** Snapshot the modifier + key state of a `KeyboardEvent` as a step. */
+function stepFromEvent(event: KeyboardEvent): ShortcutStep {
+  return {
+    ctrl: event.ctrlKey,
+    meta: event.metaKey,
+    shift: event.shiftKey,
+    alt: event.altKey,
+    key: canonicalKey(event.key),
+  };
+}
+
+function stepsEqual(a: ShortcutStep, b: ShortcutStep): boolean {
+  return (
+    a.ctrl === b.ctrl &&
+    a.meta === b.meta &&
+    a.shift === b.shift &&
+    a.alt === b.alt &&
+    a.key === b.key
+  );
+}
+
+/** Whether `steps` matches the tail of the recently pressed `buffer`. */
+function sequenceMatches(steps: ShortcutStep[], buffer: ShortcutStep[]): boolean {
+  if (steps.length === 0 || steps.length > buffer.length) return false;
+  const offset = buffer.length - steps.length;
+  for (let i = 0; i < steps.length; i++) {
+    if (!stepsEqual(steps[i], buffer[offset + i])) return false;
+  }
+  return true;
+}
+
+/** Whether focus is in a text-entry element the guard should protect. */
+function isFormElement(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof Element)) return false;
+  const tag = target.tagName.toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+  return (target as HTMLElement).isContentEditable === true;
+}
+
+interface CompiledBinding extends ShortcutBinding {
+  steps: ShortcutStep[];
+}
+
+/**
+ * Create a framework-agnostic keyboard-shortcut controller. It owns combo
+ * parsing, `keydown` matching (single combos and sequences), the form-element
+ * guard, and `preventDefault`/`stopPropagation` — never any layout or styling.
+ *
+ * SSR-safe: nothing here touches `window`/`navigator` at creation. Call
+ * {@link ShortcutControl.attach} from a client-side effect once a target exists.
+ */
+export function createShortcuts(options: ShortcutOptions = {}): ShortcutControl {
+  const sequenceTimeout = options.sequenceTimeout ?? DEFAULT_SEQUENCE_TIMEOUT;
+  const mac = options.mac ?? detectMac();
+
+  let compiled: CompiledBinding[] = [];
+  let current: ShortcutTarget | null = null;
+
+  // Recent non-modifier presses, kept in time order so sequences (`g d`) can
+  // match against the tail. Entries decay after `sequenceTimeout`.
+  let buffer: ShortcutStep[] = [];
+  let lastPressTime = 0;
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    // Ignore lone modifier presses — a combo fires on its final, non-modifier
+    // key, and letting modifiers into the buffer would break sequences.
+    if (MODIFIER_KEYS.has(event.key.toLowerCase())) return;
+
+    const now =
+      typeof event.timeStamp === 'number' && event.timeStamp > 0
+        ? event.timeStamp
+        : lastPressTime + 1;
+    if (now - lastPressTime > sequenceTimeout) buffer = [];
+    lastPressTime = now;
+
+    buffer.push(stepFromEvent(event));
+    if (buffer.length > MAX_SEQUENCE_LENGTH) {
+      buffer = buffer.slice(-MAX_SEQUENCE_LENGTH);
+    }
+
+    const inFormElement = isFormElement(event.target);
+
+    for (const binding of compiled) {
+      if (binding.enabled === false) continue;
+      if (inFormElement && !binding.enableOnFormElements) continue;
+      if (!sequenceMatches(binding.steps, buffer)) continue;
+
+      if (binding.preventDefault !== false) event.preventDefault();
+      if (binding.stopPropagation) event.stopPropagation();
+      binding.handler(event);
+    }
+  };
+
+  const detach = () => {
+    if (current) current.removeEventListener('keydown', onKeyDown as EventListener);
+    current = null;
+  };
+
+  return {
+    setBindings(bindings) {
+      compiled = bindings.map((binding) => ({
+        ...binding,
+        steps: parseCombo(binding.combo, mac),
+      }));
+    },
+    attach(target) {
+      if (target === current) return;
+      detach();
+      current = target;
+      if (target) target.addEventListener('keydown', onKeyDown as EventListener);
+    },
+    destroy: detach,
+  };
+}

--- a/packages/folds/src/shortcut/shortcut.types.ts
+++ b/packages/folds/src/shortcut/shortcut.types.ts
@@ -1,0 +1,76 @@
+/**
+ * Shortcut — a Manti-original, framework-agnostic keyboard-shortcut primitive.
+ * Like `swipe`, it is not backed by a Zag.js machine (Zag has no shortcut
+ * component); it is plain DOM + TypeScript so any renderer — or any plain JS
+ * consumer — can bind key combinations to actions.
+ */
+
+/** A DOM target a shortcut listener can attach to. */
+export type ShortcutTarget = Window | Document | HTMLElement;
+
+/** A single normalized combo step: required modifier state + the resolved key. */
+export interface ShortcutStep {
+  ctrl: boolean;
+  meta: boolean;
+  shift: boolean;
+  alt: boolean;
+  /** Canonical, lower-cased key token (e.g. `k`, `escape`, `arrowup`, `space`). */
+  key: string;
+}
+
+/** A single keyboard binding registered on a controller. */
+export interface ShortcutBinding {
+  /**
+   * The combo to match. Modifiers `mod` (⌘ on macOS / Ctrl elsewhere), `ctrl`,
+   * `shift`, `alt`/`option`, `meta`/`cmd`. Single combos (`mod+k`,
+   * `ctrl+shift+p`) or space-separated sequences (`g d`).
+   */
+  combo: string;
+  /** Fired when the combo matches. Receives the raw `KeyboardEvent`. */
+  handler: (event: KeyboardEvent) => void;
+  /**
+   * Call `event.preventDefault()` on match so browser combos (⌘R/⌘S/⌘P/⌘F)
+   * don't fire their native action. @default true
+   */
+  preventDefault?: boolean;
+  /** Call `event.stopPropagation()` on match. @default false */
+  stopPropagation?: boolean;
+  /** Toggle the binding off without removing it. @default true */
+  enabled?: boolean;
+  /**
+   * Allow the combo to fire while focus is in an `input`/`textarea`/`select`
+   * or a `contenteditable` region. @default false
+   */
+  enableOnFormElements?: boolean;
+}
+
+/** Configuration for {@link createShortcuts}. */
+export interface ShortcutOptions {
+  /**
+   * How long, in milliseconds, a multi-key sequence (`g d`) may pause between
+   * steps before it resets. @default 1000
+   */
+  sequenceTimeout?: number;
+  /**
+   * Force macOS `mod` resolution (⌘). Detected from the platform by default;
+   * override for tests or non-DOM environments.
+   */
+  mac?: boolean;
+}
+
+/** A bound shortcut controller. Drive it from a renderer's effect. */
+export interface ShortcutControl {
+  /**
+   * Replace the live binding list. Read at event time, so this never re-binds
+   * the underlying `keydown` listener — safe to call on every render.
+   */
+  setBindings(bindings: ShortcutBinding[]): void;
+  /**
+   * Attach the `keydown` listener to `target`. Idempotent: passing the same
+   * target again is a no-op; a different (or `null`) target detaches the old
+   * one first. `null` — e.g. an unmounted ref or SSR — simply detaches.
+   */
+  attach(target: ShortcutTarget | null): void;
+  /** Detach any current listener. Idempotent; safe on unmount and in SSR. */
+  destroy(): void;
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React adapter for the Manti UI design system.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,6 +27,11 @@
       "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./shortcut": {
+      "development": "./src/shortcut/index.ts",
+      "types": "./dist/shortcut/index.d.ts",
+      "import": "./dist/shortcut.js"
     }
   },
   "main": "./dist/index.js",
@@ -38,6 +43,10 @@
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./shortcut": {
+        "types": "./dist/shortcut/index.d.ts",
+        "import": "./dist/shortcut.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,4 +3,12 @@ export type { MantiUiMetadata } from './meta';
 
 export * from './components';
 
+// Also available standalone at `@manti-ui/react/shortcut` (no component deps).
+export { useShortcut, useShortcuts } from './shortcut';
+export type {
+  ShortcutMap,
+  ShortcutOptions,
+  ShortcutScope,
+} from './shortcut';
+
 export type { MantiBuiltinTone, MantiTone } from '@manti-ui/tokens';

--- a/packages/react/src/shortcut/Shortcut.stories.tsx
+++ b/packages/react/src/shortcut/Shortcut.stories.tsx
@@ -1,0 +1,191 @@
+import { useRef, useState } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { useShortcut, useShortcuts } from './useShortcut';
+import { Badge } from '../components/Badge/Badge';
+import { Button } from '../components/Button/Button';
+import { Card } from '../components/Card/Card';
+import { Dialog } from '../components/Dialog/Dialog';
+import { TextField } from '../components/TextField/TextField';
+
+const meta = {
+  title: 'Primitives/useShortcut',
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const stack: CSSProperties = {
+  display: 'grid',
+  gap: 'var(--manti-space-4)',
+  width: 340,
+};
+
+const row: CSSProperties = {
+  display: 'flex',
+  gap: 'var(--manti-space-2)',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+};
+
+const muted: CSSProperties = {
+  color: 'var(--manti-text-muted)',
+  fontSize: 'var(--manti-text-sm)',
+  lineHeight: 1.5,
+};
+
+/** A small key-combo hint, rendered with the monospace token — no colored accent. */
+function Combo({ children }: { children: ReactNode }) {
+  return (
+    <Badge variant="outline" style={{ fontFamily: 'var(--manti-font-mono)' }}>
+      {children}
+    </Badge>
+  );
+}
+
+/**
+ * Global by default: the listener sits on `window`, so `⌘K` / `Ctrl+K` opens the
+ * dialog regardless of focus — no wiring on any element. `preventDefault`
+ * defaults to `true`, so the browser's own ⌘K doesn't also fire.
+ */
+export const Global: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    useShortcut('mod+k', () => setOpen(true));
+    return (
+      <div style={stack}>
+        <div style={row}>
+          <Button onClick={() => setOpen(true)}>
+            Search… <Combo>mod+k</Combo>
+          </Button>
+        </div>
+        <p style={muted}>
+          Press <Combo>⌘K</Combo> / <Combo>Ctrl+K</Combo> anywhere on the page.
+        </p>
+        <Dialog
+          open={open}
+          onOpenChange={setOpen}
+          title="Search"
+          description="Opened by click or by the global ⌘K shortcut."
+        >
+          <TextField label="Query" placeholder="Type to search…" />
+        </Dialog>
+      </div>
+    );
+  },
+};
+
+/**
+ * Scoped to a region: pass a ref and the combo only fires while focus is inside
+ * that element. Focus the card and press `⌘S` — it saves. Click outside first
+ * and the same combo does nothing (and the browser keeps ⌘S for itself).
+ */
+export const Scoped: Story = {
+  render: () => {
+    const ref = useRef<HTMLDivElement>(null);
+    const [saves, setSaves] = useState(0);
+    useShortcut('mod+s', () => setSaves((n) => n + 1), { scope: ref });
+    return (
+      <div style={stack}>
+        {/* The ref sits on a focusable wrapper; clicking anywhere inside it
+            focuses the region, so the scoped ⌘S then fires. */}
+        <div ref={ref} tabIndex={-1} style={{ outline: 'none' }}>
+          <Card elevated style={{ padding: 'var(--manti-space-5)', ...stack }}>
+            <strong>Editor region</strong>
+            <p style={muted}>
+              Click here to focus, then press <Combo>⌘S</Combo> /{' '}
+              <Combo>Ctrl+S</Combo> to save.
+            </p>
+            <div style={row}>
+              <Badge tone={saves > 0 ? 'success' : 'neutral'}>
+                {saves > 0 ? `Saved ×${saves}` : 'Not saved'}
+              </Badge>
+            </div>
+          </Card>
+        </div>
+        <p style={muted}>
+          Focus outside the card and ⌘S falls through to the browser instead.
+        </p>
+      </div>
+    );
+  },
+};
+
+/** Bind several combos at once with `useShortcuts`. Includes a `g d` sequence. */
+export const Multiple: Story = {
+  render: () => {
+    const [log, setLog] = useState<string[]>([]);
+    const push = (label: string) =>
+      setLog((prev) => [label, ...prev].slice(0, 5));
+    useShortcuts({
+      'mod+k': () => push('mod+k → open search'),
+      'mod+/': () => push('mod+/ → toggle help'),
+      'g d': () => push('g d → go to dashboard'),
+    });
+    return (
+      <div style={stack}>
+        <div style={row}>
+          <Combo>mod+k</Combo>
+          <Combo>mod+/</Combo>
+          <Combo>g d</Combo>
+        </div>
+        <p style={muted}>
+          Try each combo. For the sequence, press <Combo>g</Combo> then{' '}
+          <Combo>d</Combo> within a second.
+        </p>
+        <Card style={{ padding: 'var(--manti-space-4)', ...stack, gap: 'var(--manti-space-1)' }}>
+          {log.length === 0 ? (
+            <span style={muted}>No shortcut fired yet.</span>
+          ) : (
+            log.map((entry, i) => (
+              <span
+                key={`${entry}-${i}`}
+                style={{
+                  fontFamily: 'var(--manti-font-mono)',
+                  fontSize: 'var(--manti-text-sm)',
+                  opacity: i === 0 ? 1 : 0.55,
+                }}
+              >
+                {entry}
+              </span>
+            ))
+          )}
+        </Card>
+      </div>
+    );
+  },
+};
+
+/**
+ * The form-element guard: by default combos don't fire while you type in an
+ * input. The first field ignores `mod+enter`; the second opts in with
+ * `enableOnFormElements` and fires from inside the input.
+ */
+export const FormGuard: Story = {
+  render: () => {
+    const [count, setCount] = useState(0);
+    useShortcut('mod+enter', () => setCount((n) => n + 1), {
+      enableOnFormElements: true,
+    });
+    return (
+      <div style={stack}>
+        <TextField
+          label="Comment"
+          placeholder="Type, then press ⌘/Ctrl+Enter to submit"
+        />
+        <div style={row}>
+          <Badge tone={count > 0 ? 'success' : 'neutral'}>
+            Submitted ×{count}
+          </Badge>
+        </div>
+        <p style={muted}>
+          <Combo>mod+enter</Combo> fires even from inside the field because this
+          binding sets <code>enableOnFormElements</code>.
+        </p>
+      </div>
+    );
+  },
+};

--- a/packages/react/src/shortcut/index.ts
+++ b/packages/react/src/shortcut/index.ts
@@ -1,0 +1,6 @@
+export { useShortcut, useShortcuts } from './useShortcut';
+export type {
+  ShortcutMap,
+  ShortcutOptions,
+  ShortcutScope,
+} from './useShortcut';

--- a/packages/react/src/shortcut/useShortcut.ts
+++ b/packages/react/src/shortcut/useShortcut.ts
@@ -1,0 +1,111 @@
+import { useEffect, useMemo } from 'react';
+import type { RefObject } from 'react';
+import { shortcut } from '@manti-ui/folds';
+
+/**
+ * Where a shortcut listens. `'global'` binds to `window`, so the combo fires
+ * regardless of focus and needs zero wiring on any element. A ref scopes firing
+ * to that element's subtree — the combo only fires while focus is inside it.
+ */
+export type ShortcutScope = 'global' | RefObject<HTMLElement | null>;
+
+export interface ShortcutOptions {
+  /** Where the combo listens. @default 'global' */
+  scope?: ShortcutScope;
+  /**
+   * Call `event.preventDefault()` on match so browser combos (⌘R/⌘S/⌘P/⌘F)
+   * don't trigger their native action. Opt out with `false`. @default true
+   */
+  preventDefault?: boolean;
+  /** Toggle the binding without unmounting. @default true */
+  enabled?: boolean;
+  /**
+   * Fire even while focus is in an `input`/`textarea`/`select` or a
+   * `contenteditable` region. @default false
+   */
+  enableOnFormElements?: boolean;
+  /** Also call `event.stopPropagation()` on match. @default false */
+  stopPropagation?: boolean;
+  /**
+   * How long, in ms, a multi-key sequence (`g d`) may pause between steps
+   * before it resets. @default 1000
+   */
+  sequenceTimeout?: number;
+}
+
+/** A combo → handler map for {@link useShortcuts}. */
+export type ShortcutMap = Record<string, (event: KeyboardEvent) => void>;
+
+function resolveTarget(scope: ShortcutScope): shortcut.ShortcutTarget | null {
+  if (scope === 'global') {
+    return typeof window !== 'undefined' ? window : null;
+  }
+  return scope.current;
+}
+
+/**
+ * Bind one or more keyboard combos to handlers on any component — Manti UI or
+ * your own — via the framework-agnostic engine in `@manti-ui/folds`. The engine
+ * is created once; bindings refresh every render (so handlers stay current)
+ * without ever re-binding the `keydown` listener.
+ *
+ * SSR-safe: the listener is only attached inside an effect, never at module
+ * load. Prefer {@link useShortcut}/{@link useShortcuts}; this is the shared core.
+ */
+function useShortcutEngine(bindings: shortcut.ShortcutBinding[], options: ShortcutOptions) {
+  const { scope = 'global', sequenceTimeout } = options;
+  // Created once; live config flows through `setBindings`/`attach` below,
+  // matching the Swipe adapter's pattern. `sequenceTimeout` is read at creation.
+  const control = useMemo(() => shortcut.createShortcuts({ sequenceTimeout }), [sequenceTimeout]);
+
+  // Refresh bindings + target every render so the listener reads the latest
+  // handlers and scope. `setBindings` never re-binds the listener, and `attach`
+  // no-ops when the target is unchanged — so this is cheap on every render.
+  useEffect(() => {
+    control.setBindings(bindings);
+    control.attach(resolveTarget(scope));
+  });
+
+  useEffect(() => () => control.destroy(), [control]);
+}
+
+/**
+ * Bind a single keyboard combo to a handler.
+ *
+ * @example
+ * useShortcut('mod+k', () => setOpen(true)); // global, preventDefault by default
+ *
+ * @example
+ * const ref = useRef<HTMLDivElement>(null);
+ * useShortcut('mod+s', save, { scope: ref }); // only while focus is inside `ref`
+ */
+export function useShortcut(
+  combo: string,
+  handler: (event: KeyboardEvent) => void,
+  options: ShortcutOptions = {},
+): void {
+  const { preventDefault, enabled, enableOnFormElements, stopPropagation } = options;
+  useShortcutEngine(
+    [{ combo, handler, preventDefault, enabled, enableOnFormElements, stopPropagation }],
+    options,
+  );
+}
+
+/**
+ * Bind a map of combos to handlers in one call. Options apply to every binding.
+ *
+ * @example
+ * useShortcuts({ 'mod+k': openSearch, 'mod+/': toggleHelp, 'g d': goDashboard });
+ */
+export function useShortcuts(map: ShortcutMap, options: ShortcutOptions = {}): void {
+  const { preventDefault, enabled, enableOnFormElements, stopPropagation } = options;
+  const bindings = Object.entries(map).map(([combo, handler]) => ({
+    combo,
+    handler,
+    preventDefault,
+    enabled,
+    enableOnFormElements,
+    stopPropagation,
+  }));
+  useShortcutEngine(bindings, options);
+}

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -3,8 +3,12 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   build: {
     lib: {
-      entry: 'src/index.ts',
-      fileName: 'index',
+      // Multi-entry: the root package plus the standalone `@manti-ui/react/shortcut`
+      // subpath. Output file names follow the entry keys (`index.js`, `shortcut.js`).
+      entry: {
+        index: 'src/index.ts',
+        shortcut: 'src/shortcut/index.ts',
+      },
       formats: ['es'],
     },
     rollupOptions: {

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/styles",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Framework-agnostic CSS for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/styles/src/components/button.css
+++ b/packages/styles/src/components/button.css
@@ -89,7 +89,7 @@
       backdrop-filter: var(--manti-panel-blur);
       border-color: var(--manti-panel-border);
       color: var(--tone-soft-text);
-      box-shadow: inset 0 1px 0 0 var(--manti-panel-highlight);
+      box-shadow: inset 0 0 5px 0 var(--manti-panel-highlight);
 
       &:hover {
         background: color-mix(

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/tokens",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Framework-agnostic design token contract for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,6 +12,7 @@
     "paths": {
       "@manti-ui/folds": ["./packages/folds/src/index.ts"],
       "@manti-ui/react": ["./packages/react/src/index.ts"],
+      "@manti-ui/react/shortcut": ["./packages/react/src/shortcut/index.ts"],
       "@manti-ui/styles": ["./packages/styles/src/index.ts"],
       "@manti-ui/tokens": ["./packages/tokens/src/index.ts"]
     },


### PR DESCRIPTION
Promotes `dev` → `main` to publish **v0.3.0**.

On merge, `release.yml` runs on the `main` push: with no changeset files but the four `@manti-ui/*` packages at 0.3.0 (ahead of npm's 0.2.0), the changesets action runs `publish` (`build:packages` + `changeset publish`), then tags **`v0.3.0`** and cuts the GitHub Release.

## Shipping in 0.3.0
- **Added:** `useShortcut` / `useShortcuts` keyboard-shortcut primitive (#35) + standalone `@manti-ui/react/shortcut` subpath.
- **Changed:** Button soft-variant highlight softened to an inset glow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)