### PR TITLE
chore(release): version packages to 0.6.0

### DIFF
--- a/packages/docs/src/content/changelog/v0-1-0.mdx
+++ b/packages/docs/src/content/changelog/v0-1-0.mdx
@@ -2,7 +2,7 @@
 title: v0.1.0
 slug: /changelog/v0.1.0
 group: Changelog
-order: 10
+order: 11
 date: '2026-06-23'
 description: The first public release of Manti UI — the design-token contract, the monochrome design signature, and the initial component set, published to npm.
 ---

--- a/packages/docs/src/content/changelog/v0-1-1.mdx
+++ b/packages/docs/src/content/changelog/v0-1-1.mdx
@@ -2,7 +2,7 @@
 title: v0.1.1
 slug: /changelog/v0.1.1
 group: Changelog
-order: 9
+order: 10
 date: '2026-06-26'
 description: A TanStack-backed DataTable, a categorized collapsible docs sidebar, the panel token rename, scrollable Combobox and Select listboxes, and overlay fixes.
 ---

--- a/packages/docs/src/content/changelog/v0-1-2.mdx
+++ b/packages/docs/src/content/changelog/v0-1-2.mdx
@@ -2,7 +2,7 @@
 title: v0.1.2
 slug: /changelog/v0.1.2
 group: Changelog
-order: 8
+order: 9
 date: '2026-06-29'
 description: A new Textarea multiline field, per-node TreeView icons, scrollable TimePicker columns, a tonal Listbox selection, and Combobox and TagsInput refinements.
 ---

--- a/packages/docs/src/content/changelog/v0-1-3.mdx
+++ b/packages/docs/src/content/changelog/v0-1-3.mdx
@@ -2,7 +2,7 @@
 title: v0.1.3
 slug: /changelog/v0.1.3
 group: Changelog
-order: 7
+order: 8
 date: '2026-07-01'
 description: A centered ColorPicker slider thumb and an optional swatch-only trigger.
 ---

--- a/packages/docs/src/content/changelog/v0-1-4.mdx
+++ b/packages/docs/src/content/changelog/v0-1-4.mdx
@@ -2,7 +2,7 @@
 title: v0.1.4
 slug: /changelog/v0.1.4
 group: Changelog
-order: 6
+order: 7
 date: '2026-07-01'
 description: A reworked Splitter resize handle that widens without reflowing panels, plus three Splitter component tokens.
 ---

--- a/packages/docs/src/content/changelog/v0-1-5.mdx
+++ b/packages/docs/src/content/changelog/v0-1-5.mdx
@@ -2,7 +2,7 @@
 title: v0.1.5
 slug: /changelog/v0.1.5
 group: Changelog
-order: 5
+order: 6
 date: '2026-07-03'
 description: 'Two fixes: Tabs no longer leak trigger and indicator styles into embedded components, and Clipboard keeps a neutral focus border until a copy succeeds.'
 ---

--- a/packages/docs/src/content/changelog/v0-2-0.mdx
+++ b/packages/docs/src/content/changelog/v0-2-0.mdx
@@ -2,7 +2,7 @@
 title: v0.2.0
 slug: /changelog/v0.2.0
 group: Changelog
-order: 4
+order: 5
 date: '2026-07-04'
 description: A month-grid Calendar, a ColorPicker copy area with eyedropper and format tabs, a compact Tabs size, new Button and Checkbox tokens, and two anatomy changes.
 ---

--- a/packages/docs/src/content/changelog/v0-3-0.mdx
+++ b/packages/docs/src/content/changelog/v0-3-0.mdx
@@ -2,7 +2,7 @@
 title: v0.3.0
 slug: /changelog/v0.3.0
 group: Changelog
-order: 3
+order: 4
 date: '2026-07-13'
 description: A framework-agnostic keyboard-shortcut primitive — useShortcut / useShortcuts — bindable to any component, plus a softer Button soft-variant highlight.
 ---

--- a/packages/docs/src/content/changelog/v0-4-0.mdx
+++ b/packages/docs/src/content/changelog/v0-4-0.mdx
@@ -2,7 +2,7 @@
 title: v0.4.0
 slug: /changelog/v0.4.0
 group: Changelog
-order: 2
+order: 3
 date: '2026-07-19'
 description: TextField is renamed to Input and PasswordInput folds into <Input type="password">, plus panel rim/inset box-shadows become semantic tokens.
 ---

--- a/packages/docs/src/content/changelog/v0-5-0.mdx
+++ b/packages/docs/src/content/changelog/v0-5-0.mdx
@@ -2,7 +2,7 @@
 title: v0.5.0
 slug: /changelog/v0.5.0
 group: Changelog
-order: 1
+order: 2
 date: '2026-07-25'
 description: Colour ramps are re-indexed 1-12 and audited with a contrast gate, secondary becomes amber, and radius splits size from shape with data-radius presets.
 ---

--- a/packages/docs/src/content/changelog/v0-6-0.mdx
+++ b/packages/docs/src/content/changelog/v0-6-0.mdx
@@ -1,0 +1,150 @@
+---
+title: v0.6.0
+slug: /changelog/v0.6.0
+group: Changelog
+order: 1
+date: '2026-07-27'
+description: Surfaces go flat, secondary returns to neutral, success and info join the variant set, the input family gets a default/fill axis, and the docs ship llms.txt.
+---
+
+# v0.6.0
+
+_Released 2026-07-27._
+
+## Breaking changes
+
+- **`secondary` is neutral again.** v0.5.0 made it amber; this release puts it
+  back on the gray family and follows the shared role contract (`3`/`4` for
+  component rest/hover, `11` for readable soft text). The emphasis ladder is
+  monochrome below `primary` once more, so a `secondary` Badge or Button no
+  longer collides with warning semantics. If you adopted amber deliberately in
+  0.5.0, it is still one override away:
+
+  ```css
+  [data-variant='secondary'] {
+    --variant-soft-bg: var(--manti-amber-2);
+    --variant-soft-text: var(--manti-amber-10);
+  }
+  ```
+
+- **`success` and `info` join the variant set.** `variants` in
+  `@manti-ui/tokens` is now `primary`, `secondary`, `success`, `info`,
+  `tertiary`, `danger`, `outline` — green and blue built the same way as the
+  other chromatic variants, with `--variant-on-solid` measured rather than
+  picked. Anything that enumerates `MantiBuiltinVariant` (a `Record`, a
+  `switch`, a props table) sees two new members.
+
+- **Variant props are narrowed per component.** `variant` used to be
+  `MantiVariant` everywhere, which typed combinations no component ever
+  rendered. Each component that constrains the set now exports its own union:
+
+  - `AlertVariant` — `primary | secondary | success | info | danger`. Alert
+    drops `tertiary` and `outline`; there is no ghost or bordered message panel.
+  - `BadgeVariant` — every built-in variant except `tertiary`. The label-only
+    treatment is gone; reach for `outline` for the quietest chip.
+  - `InputVariant`, `TextareaVariant`, `SelectVariant`, `ComboboxVariant` — see
+    below.
+
+- **The input family's `variant` is no longer a color.** Input, Textarea, Select
+  and Combobox took a `MantiVariant` that only ever tinted the focus ring. It is
+  now a visual treatment, `'default' | 'fill'`, defaulting to `'default'`; the
+  ring follows `primary` regardless. A color passed today resolves to neither
+  treatment and fails typecheck.
+
+  ```diff
+  -<Input variant="primary" />
+  +<Input />          {/* outlined — the default */}
+  +<Input variant="fill" />  {/* filled: no resting border, --manti-fill surface */}
+  ```
+
+## Surfaces are flat
+
+The translucent panel treatment — `backdrop-filter`, the tint/rim/inset triad —
+is removed from Button, Badge, Alert, Collapsible and the whole field family.
+Blur is expensive to composite, it dropped out entirely on the `@supports`
+fallback path (so two users saw two different designs), and layered over a busy
+page it read as noise rather than depth. Those components now paint an opaque
+surface with a real border.
+
+- Solid controls keep their inner top highlight, but it is mixed off
+  `--variant-on-solid` instead of a hard-coded white, so it stays legible on
+  every variant.
+- Soft treatments (Button, Badge, Alert `secondary`) merge the border into the
+  fill: the one-pixel footprint survives for stable sizing, without drawing a
+  contrasting edge.
+- Blur-less `@supports` blocks are deleted along with the effect they guarded.
+
+## The input border progression, applied
+
+The control family — Input, Textarea, Select, Combobox and friends — now follows
+one rule end to end: `--manti-border` at rest, `--manti-border-strong` on hover,
+`--variant-ring` once active, focused or open. Primary color starts at focus and
+never appears on a resting border.
+
+- **`fill` appearance.** `data-appearance="fill"` swaps the outlined control for
+  a borderless `--manti-fill` surface that strengthens to `--manti-fill-strong`
+  on hover and focus, then shows the ring on focus.
+- **Select and Combobox connect to their popup.** The trigger reads
+  `data-connected="top" | "bottom"` from the positioner's resolved side and
+  drops the matching corner radii and border edge, so trigger and listbox read as
+  one shape. Closed or empty, the attribute is absent — no bottomless box on a
+  focused-but-closed trigger.
+- Invalid states, the required marker, the error message and the caps-lock
+  notice all move onto new semantic roles instead of reaching into the red and
+  amber ramps directly.
+
+## Components
+
+- **Collapsible** renders a state-aware chevron indicator by default — expand on
+  closed, collapse on open. Pass `indicator` for your own node or `false` to
+  suppress it; size it with the new `--manti-collapsible-icon-size` token. The
+  trigger's padding tightens by one step.
+- **Menu** accepts `bottom-center` as a placement alias for `bottom`, typed as
+  the new `MenuPlacement`.
+- **ColorPicker** pins its root to the primary variant so its ring matches the
+  rest of the control family.
+- **Button**'s `sm` step tightens: `--manti-space-2` of inline padding and a
+  radius factor of `0.8` rather than `0.7`.
+
+## Tokens
+
+- **Semantic status roles.** `--manti-danger-icon`, `--manti-danger-border`,
+  `--manti-danger-text`, `--manti-warning-text`, `--manti-accent-fill` and
+  `--manti-contrast-light` replace the `light-dark(var(--manti-red-8), …)` pairs
+  that had been inlined across component CSS. Both text roles are now audited by
+  the contrast gate.
+- **`colorScaleRoles` is exported** from `@manti-ui/tokens` — the `1`–`12`
+  contract (app background, component background, border, solid, text) as typed
+  data rather than prose, and reachable as `mantiTokens.color.scaleRoles`.
+- **A color-scale gate runs in the styles build.** `check:color-scale` fails the
+  build when component CSS names a raw color or a primitive ramp stop directly,
+  and when a built-in variant assigns a role a stop outside its band (borders
+  `6`–`8`, rings `7`–`8`, solids `9`–`10`, with the documented exceptions).
+  Available standalone as `pnpm check:color-scale`.
+- **The `pill` radius preset is dropped; the channel stays.** `pill` shared
+  `round`'s factor of `1.4` and differed only by raising `--manti-radius-pill`,
+  which the parts that read as unmistakably pill are pinned past anyway — so on
+  a real page the step showed no visible difference. Four presets remain, one per
+  distinct factor: `none` `0`, `sharp` `0.6`, `default` `1`, `round` `1.4`.
+  Nothing is lost, and raising the channel now composes with any factor:
+
+  ```css
+  :root {
+    --manti-radius-pill: 9999px;
+  }
+  ```
+
+## Documentation
+
+- **`llms.txt`** ships at [manti.design/llms.txt](https://manti.design/llms.txt)
+  — a condensed technical map of the install, the token tiers, the anatomy
+  contract and the component surface, written for coding agents. The new
+  _Working with AI_ page links and downloads it.
+- **The `size` prop is documented on the twelve components that shipped it
+  without showing it**: Badge, Combobox, DataTable, Drawer, Pagination, PinInput,
+  Progress, RatingGroup, Select, Spinner, Tabs and ToggleGroup. Each gets a
+  `## Sizes` section, because the prop scales something different in each —
+  control height, row density, panel extent, track thickness.
+- The repository guides (`README`, architecture, styling, design-system, token
+  and coverage docs) are rewritten against the current token system, and every
+  component page picks up the new variant vocabulary.

--- a/packages/folds/package.json
+++ b/packages/folds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/folds",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Framework-agnostic Zag.js behavior contracts for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/react",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "React adapter for the Manti UI design system.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/styles",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Framework-agnostic CSS for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manti-ui/tokens",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Framework-agnostic design token contract for Manti UI.",
   "license": "MIT",
   "homepage": "https://manti.design",


### PR DESCRIPTION
Cuts **v0.6.0** for the fixed group (`@manti-ui/tokens`, `@manti-ui/styles`, `@manti-ui/folds`, `@manti-ui/react`), covering everything merged to `main` after the v0.5.0 tag: #80/#82/#83 — the component + token + documentation refinement pass, the `size` prop documentation sweep, and the `pill` radius preset removal.

The bump is **manual, not `changeset version`** — the `fixed` group escalates a 0.x `minor` straight to 1.0.0. Merging this to `main` makes `release.yml` publish to npm (versions ahead, no changesets pending) and cut the `v0.6.0` tag + GitHub Release.

### Breaking

- `secondary` returns to the neutral gray family — v0.5.0 had made it amber.
- `success` and `info` join `variants`, so `MantiBuiltinVariant` gains two members.
- `AlertVariant` (drops `tertiary`/`outline`) and `BadgeVariant` (drops `tertiary`) replace `MantiVariant` on those props.
- `Input`/`Textarea`/`Select`/`Combobox` `variant` becomes `'default' | 'fill'` — a visual treatment, not a color.

### Changed

- The translucent panel treatment (`backdrop-filter`, tint/rim/inset) is removed from Button, Badge, Alert, Collapsible and the field family; surfaces are flat and opaque.
- The control family applies the border progression end to end: `--manti-border` rest → `--manti-border-strong` hover → `--variant-ring` active/focus/open. Select and Combobox connect to their popup via `data-connected`.

### Added

- Semantic status roles (`--manti-danger-icon/-border/-text`, `--manti-warning-text`, `--manti-accent-fill`, `--manti-contrast-light`), the exported `colorScaleRoles` contract, and a `check:color-scale` gate in the styles build.
- Collapsible's default state-aware indicator + `--manti-collapsible-icon-size`, `MenuPlacement`'s `bottom-center` alias, `llms.txt` and the Working with AI docs page.

### Removed

- The `pill` radius preset. The `--manti-radius-pill` channel stays and now composes with any factor.

### Verification

- `pnpm verify` (lint, typecheck, package builds, Storybook build) — pass
- `pnpm docs:build` — pass; `/changelog/v0.6.0` prerenders, so the header's "what's new" badge resolves.

### Follow-up

`dev` is still on 0.4.0 — it needs `main` merged back after this ships.